### PR TITLE
Add paths for tree graphs

### DIFF
--- a/src/Graphs/abstractgraph.jl
+++ b/src/Graphs/abstractgraph.jl
@@ -43,6 +43,19 @@ function incident_edges(graph::AbstractGraph, vertex...)
   ]
 end
 
+# Get the leaf vertices of a tree-like graph
+# 
+# For the directed case, could also use `AbstractTrees`:
+#
+# root_index = findfirst(vertex -> length(outneighbors(vertex)) == length(neighbors(vertex)), vertices(graph))
+# root = vertices(graph)[root_index]
+# [node.vertex for node in Leaves(TreeGraph(graph, root))]
+#
+function leaf_vertices(graph::AbstractGraph)
+  # @assert is_tree(graph)
+  return filter(v -> is_leaf(graph, v...), vertices(graph))
+end
+
 #
 # Graph iteration
 #
@@ -60,12 +73,6 @@ end
 @traitfn function is_leaf(graph::::(!IsDirected), vertex...)
   # @assert is_tree(graph)
   return isone(length(neighbors(graph, vertex...)))
-end
-
-# Get the leaf vertices of an undirected tree-like graph
-@traitfn function leaf_vertices(graph::::(!IsDirected))
-  # @assert is_tree(graph)
-  return [vertex for vertex in vertices(graph) if isone(length(neighbors(graph, vertex)))]
 end
 
 # Paths for undirected tree-like graphs
@@ -122,21 +129,6 @@ end
 @traitfn function is_leaf(graph::::IsDirected, vertex...)
   # @assert is_tree(graph)
   return isempty(outneighbors(graph, vertex...))
-end
-
-# Get the leaf vertices of a directed tree-like graph.
-# Assumes it is a [rooted directed tree](https://en.wikipedia.org/wiki/Tree_(graph_theory)#Rooted_tree)
-# with edges pointed away from the root. The root is the only vertex with out edges.
-#
-# Could also use `AbstractTrees` for this:
-#
-# root_index = findfirst(vertex -> length(outneighbors(vertex)) == length(neighbors(vertex)), vertices(graph))
-# root = vertices(graph)[root_index]
-# [node.vertex for node in Leaves(TreeGraph(graph, root))]
-#
-@traitfn function leaf_vertices(graph::::IsDirected)
-  # @assert is_tree(graph)
-  return [vertex for vertex in vertices(graph) if isempty(outneighbors(graph, vertex))]
 end
 
 # Traverse the tree using a [post-order depth-first search](https://en.wikipedia.org/wiki/Tree_traversal#Depth-first_search), returning the vertices.

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -84,6 +84,8 @@ export NamedGraph,
   is_tree,
   parent_vertex,
   child_vertices,
-  leaf_vertices
+  leaf_vertices,
+  vertex_path,
+  edge_path
 
 end # module AbstractNamedGraphs

--- a/test/test_abstractgraph.jl
+++ b/test/test_abstractgraph.jl
@@ -1,0 +1,58 @@
+using Test
+using Graphs
+using NamedGraphs
+
+@testset "Tree graph paths" begin
+  # undirected trees
+  g1 = comb_tree((3, 2))
+  et1 = edgetype(g1)
+  @test vertex_path(g1, 4, 5) == [4, 1, 2, 5]
+  @test edge_path(g1, 4, 5) == [et1(4, 1), et1(1, 2), et1(2, 5)]
+  @test vertex_path(g1, 6, 1) == [6, 3, 2, 1]
+  @test edge_path(g1, 6, 1) == [et1(6, 3), et1(3, 2), et1(2, 1)]
+  @test vertex_path(g1, 2, 2) == [2]
+  @test edge_path(g1, 2, 2) == et1[]
+
+  ng1 = named_comb_tree((3, 2))
+  net1 = edgetype(ng1)
+  @test vertex_path(ng1, (1, 2), (2, 2)) == [(1, 2), (1, 1), (2, 1), (2, 2)]
+  @test edge_path(ng1, (1, 2), (2, 2)) ==
+    [net1((1, 2), (1, 1)), net1((1, 1), (2, 1)), net1((2, 1), (2, 2))]
+  @test vertex_path(ng1, (3, 2), (1, 1)) == [(3, 2), (3, 1), (2, 1), (1, 1)]
+  @test edge_path(ng1, (3, 2), (1, 1)) ==
+    [net1((3, 2), (3, 1)), net1((3, 1), (2, 1)), net1((2, 1), (1, 1))]
+  @test vertex_path(ng1, (1, 2), (1, 2)) == [(1, 2)]
+  @test edge_path(ng1, (1, 2), (1, 2)) == net1[]
+
+  g2 = binary_tree(3)
+  et2 = edgetype(g2)
+  @test vertex_path(g2, 2, 6) == [2, 1, 3, 6]
+  @test edge_path(g2, 2, 6) == [et2(2, 1), et2(1, 3), et2(3, 6)]
+  @test vertex_path(g2, 5, 4) == [5, 2, 4]
+  @test edge_path(g2, 5, 4) == [et2(5, 2), et2(2, 4)]
+
+  ng2 = named_binary_tree(3)
+  net2 = edgetype(ng2)
+  @test vertex_path(ng2, (1, 1), (1, 2, 1)) == [(1, 1), (1,), (1, 2), (1, 2, 1)]
+  @test edge_path(ng2, (1, 1), (1, 2, 1)) ==
+    [net2((1, 1), (1,)), net2((1,), (1, 2)), net2((1, 2), (1, 2, 1))]
+  @test vertex_path(ng2, (1, 1, 2), (1, 1, 1)) == [(1, 1, 2), (1, 1), (1, 1, 1)]
+  @test edge_path(ng2, (1, 1, 2), (1, 1, 1)) ==
+    [net2((1, 1, 2), (1, 1)), net2((1, 1), (1, 1, 1))]
+
+  # undirected trees
+  dg1 = dfs_tree(g1, 5)
+  # same behavior if path exists
+  @test vertex_path(dg1, 4, 5) == [4, 1, 2, 5]
+  @test edge_path(dg1, 4, 5) == [et1(4, 1), et1(1, 2), et1(2, 5)]
+  # returns nothing if path does not exists
+  @test isnothing(vertex_path(dg1, 4, 6))
+  @test isnothing(edge_path(dg1, 4, 6))
+
+  dng1 = dfs_tree(ng1, (2, 2))
+  @test vertex_path(dng1, (1, 2), (2, 2)) == [(1, 2), (1, 1), (2, 1), (2, 2)]
+  @test edge_path(dng1, (1, 2), (2, 2)) ==
+    [net1((1, 2), (1, 1)), net1((1, 1), (2, 1)), net1((2, 1), (2, 2))]
+  @test isnothing(vertex_path(dng1, (1, 2), (3, 2)))
+  @test isnothing(edge_path(dng1, (1, 2), (3, 2)))
+end

--- a/test/test_abstractgraph.jl
+++ b/test/test_abstractgraph.jl
@@ -40,7 +40,7 @@ using NamedGraphs
   @test edge_path(ng2, (1, 1, 2), (1, 1, 1)) ==
     [net2((1, 1, 2), (1, 1)), net2((1, 1), (1, 1, 1))]
 
-  # undirected trees
+  # directed trees
   dg1 = dfs_tree(g1, 5)
   # same behavior if path exists
   @test vertex_path(dg1, 4, 5) == [4, 1, 2, 5]
@@ -55,4 +55,25 @@ using NamedGraphs
     [net1((1, 2), (1, 1)), net1((1, 1), (2, 1)), net1((2, 1), (2, 2))]
   @test isnothing(vertex_path(dng1, (1, 2), (3, 2)))
   @test isnothing(edge_path(dng1, (1, 2), (3, 2)))
+end
+
+@testset "Tree graph leaf vertices" begin
+  # undirected trees
+  g = comb_tree((3, 2))
+  @test is_leaf(g, 4)
+  @test !is_leaf(g, 1)
+  @test issetequal(leaf_vertices(g), [4, 5, 6])
+
+  ng = named_comb_tree((3, 2))
+  @test is_leaf(ng, 1, 2)
+  @test is_leaf(ng, 2, 2)
+  @test !is_leaf(ng, (1, 1))
+  @test issetequal(leaf_vertices(ng), [(1, 2), (2, 2), (3, 2)])
+
+  # directed trees
+  dng = dfs_tree(ng, (2, 2))
+  @test is_leaf(dng, 1, 2)
+  @test !is_leaf(dng, 2, 2)
+  @test !is_leaf(dng, (1, 1))
+  @test issetequal(leaf_vertices(dng), [(1, 2), (3, 2)])
 end


### PR DESCRIPTION
Request to add some functionalities for finding paths on tree graphs, which are particularly useful for certain tree tensor network routines. A summary of the changes:

- Added a function `vertex_path(graph, s, t)` which returns the list of vertices along the path from the source vertex `s` to the target vertex `t`. For a directed tree, if there is no path between `s` and `t` the function returns `nothing`.
- Added a function `edge_path(graph, s, t)` which returns the list of edges along the path from the source vertex `s` to the target vertex `t` (where the edges are directed from `s` to `t`). For a directed tree, if there is no path between `s` and `t` the function returns `nothing`.
- Small change to `parent_vertex` such that it returns `nothing` when requesting the parent vertex of the tree root (as this case would throw an error before).
- Change in the definition used for a leaf vertex of a rooted directed tree to a vertex with no children, as well as fixing some typos in related methods.