### PR TITLE
Extend comb tree constructors

### DIFF
--- a/src/Graphs/generators/staticgraphs.jl
+++ b/src/Graphs/generators/staticgraphs.jl
@@ -1,14 +1,25 @@
-function comb_tree(dims)
+function comb_tree(dims::Tuple)
   @assert length(dims) == 2
   nx, ny = dims
-  graph = grid(dims)
-  # TODO: rem_vertex!
-  for I in CartesianIndices((nx, ny))
-    jx, jy = Tuple(I)
-    j = LinearIndices((nx, ny))[I]
-    if jy > 1 && jx < nx
-      println("Remove $j => $(j + 1)")
-      rem_edge!(graph, Edge(j, j + 1))
+  return comb_tree(fill(ny, nx))
+end
+
+function comb_tree(tooth_lengths::Vector{<:Integer})
+  @assert all(>(0), tooth_lengths)
+  nv = sum(tooth_lengths)
+  nx = length(tooth_lengths)
+  ny = maximum(tooth_lengths)
+  vertex_coordinates = filter(Tuple.(CartesianIndices((nx, ny)))) do (jx, jy)
+    jy <= tooth_lengths[jx]
+  end
+  coordinate_to_vertex = Dictionary(vertex_coordinates, 1:nv)
+  graph = SimpleGraph(nv)
+  for (jx, jy) in vertex_coordinates
+    if jy == 1 && jx < nx
+      add_edge!(graph, coordinate_to_vertex[(jx, jy)], coordinate_to_vertex[(jx + 1, jy)])
+    end
+    if jy < tooth_lengths[jx]
+      add_edge!(graph, coordinate_to_vertex[(jx, jy)], coordinate_to_vertex[(jx, jy + 1)])
     end
   end
   return graph

--- a/src/generators/named_staticgraphs.jl
+++ b/src/generators/named_staticgraphs.jl
@@ -61,7 +61,18 @@ function named_grid(dims; periodic=false)
   return NamedDimGraph(simple_graph; dims=dims)
 end
 
-function named_comb_tree(dims)
+function named_comb_tree(dims::Tuple)
   simple_graph = comb_tree(dims)
   return NamedDimGraph(simple_graph; dims=dims)
+end
+
+function named_comb_tree(tooth_lengths::Vector{<:Integer})
+  @assert all(>(0), tooth_lengths)
+  simple_graph = comb_tree(tooth_lengths)
+  nx = length(tooth_lengths)
+  ny = maximum(tooth_lengths)
+  vertices = filter(Tuple.(CartesianIndices((nx, ny)))) do (jx, jy)
+    jy <= tooth_lengths[jx]
+  end
+  return NamedDimGraph(simple_graph; vertices)
 end

--- a/test/test_staticgraphs.jl
+++ b/test/test_staticgraphs.jl
@@ -1,0 +1,41 @@
+using Test
+using Graphs
+using NamedGraphs
+using Random
+
+@testset "Comb tree constructors" begin
+  Random.seed!(1234)
+
+  # construct from tuple dimension
+  dim = (rand(2:5), rand(1:5))
+  ct1 = comb_tree(dim)
+  @test nv(ct1) == prod(dim)
+  @test ne(ct1) == prod(dim) - 1
+  nct1 = named_comb_tree(dim)
+  @show vertices
+  for v in Graphs.vertices(nct1) # naming collising with other test
+    for n in neighbors(nct1, v)
+      if v[2] == 1
+        @test ((abs.(v .- n) == (1, 0)) ⊻ (abs.(v .- n) == (0, 1)))
+      else
+        @test (abs.(v .- n) == (0, 1))
+      end
+    end
+  end
+
+  # construct from random vector of tooth lengths
+  tooth_lengths = rand(1:5, rand(2:5))
+  ct2 = comb_tree(tooth_lengths)
+  @test nv(ct2) == sum(tooth_lengths)
+  @test ne(ct2) == sum(tooth_lengths) - 1
+  nct2 = named_comb_tree(tooth_lengths)
+  for v in Graphs.vertices(nct2) # naming collising with other test
+    for n in neighbors(nct2, v)
+      if v[2] == 1
+        @test ((abs.(v .- n) == (1, 0)) ⊻ (abs.(v .- n) == (0, 1)))
+      else
+        @test (abs.(v .- n) == (0, 1))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Request to extend the constructors for comb trees to handle cases where not all 'teeth' of the comb have the same length. I've added a method which takes a vector of integers specifying the length of each tooth. The vertex labeling remains the same as that of a 2d grid, where now some vertices of the underlying grid can be missing.