### PR TITLE
Add some AbstractNamedGraph functionalities

### DIFF
--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -79,6 +79,7 @@ export NamedGraph,
   named_comb_tree,
   post_order_dfs_vertices,
   post_order_dfs_edges,
+  rename_vertices,
   # Operations for tree-like graphs
   is_leaf,
   is_tree,

--- a/src/abstractnamededge.jl
+++ b/src/abstractnamededge.jl
@@ -30,6 +30,6 @@ set_dst(e::AbstractNamedEdge, dst) = set_vertices(e, src(e), dst)
 
 rename_vertices(f::Function, e::AbstractNamedEdge) = set_vertices(e, f(src(e)), f(dst(e)))
 
-function rename_vertices(e::AbstractNamedEdge, name_map::Dictionary)
+function rename_vertices(e::AbstractNamedEdge, name_map)
   return rename_vertices(v -> name_map[v], e)
 end

--- a/src/abstractnamededge.jl
+++ b/src/abstractnamededge.jl
@@ -24,3 +24,9 @@ function ==(e1::AbstractNamedEdge, e2::AbstractNamedEdge)
   return (src(e1) == src(e2) && dst(e1) == dst(e2))
 end
 hash(e::AbstractNamedEdge, h::UInt) = hash(src(e), hash(dst(e), h))
+
+function rename_vertices(e::ET, name_map::Dictionary) where {ET<:AbstractNamedEdge}
+  # strip type parameter to allow renaming to change the vertex type
+  base_edge_type = Base.typename(ET).wrapper
+  return base_edge_type(name_map[src(e)], name_map[dst(e)])
+end

--- a/src/abstractnamededge.jl
+++ b/src/abstractnamededge.jl
@@ -25,8 +25,11 @@ function ==(e1::AbstractNamedEdge, e2::AbstractNamedEdge)
 end
 hash(e::AbstractNamedEdge, h::UInt) = hash(src(e), hash(dst(e), h))
 
-function rename_vertices(e::ET, name_map::Dictionary) where {ET<:AbstractNamedEdge}
-  # strip type parameter to allow renaming to change the vertex type
-  base_edge_type = Base.typename(ET).wrapper
-  return base_edge_type(name_map[src(e)], name_map[dst(e)])
+set_src(e::AbstractNamedEdge, src) = set_vertices(e, src, dst(e))
+set_dst(e::AbstractNamedEdge, dst) = set_vertices(e, src(e), dst)
+
+rename_vertices(f::Function, e::AbstractNamedEdge) = set_vertices(e, f(src(e)), f(dst(e)))
+
+function rename_vertices(e::AbstractNamedEdge, name_map::Dictionary)
+  return rename_vertices(v -> name_map[v], e)
 end

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -237,3 +237,33 @@ function show(io::IO, mime::MIME"text/plain", graph::AbstractNamedGraph)
 end
 
 show(io::IO, graph::AbstractNamedGraph) = show(io, MIME"text/plain"(), graph)
+
+# 
+# Convenience functions
+#
+
+function Base.:(==)(g1::GT, g2::GT) where {GT<:AbstractNamedGraph}
+  issetequal(vertices(g1), vertices(g2)) || return false
+  for v in vertices(g1)
+    issetequal(inneighbors(g1, v), inneighbors(g2, v)) || return false
+    issetequal(outneighbors(g1, v), outneighbors(g2, v)) || return false
+  end
+  return true
+end
+
+function rename_vertices(g::GT, name_map::Dictionary) where {GT<:AbstractNamedGraph}
+  original_vertices = vertices(g)
+  new_vertices = getindices(name_map, original_vertices)
+  # strip type parameter to allow renaming to change the vertex type
+  base_graph_type = Base.typename(GT).wrapper
+  new_g = base_graph_type(new_vertices)
+  for e in edges(g)
+    add_edge!(new_g, rename_vertices(e, name_map))
+  end
+  return new_g
+end
+
+function rename_vertices(g::AbstractNamedGraph, name_map::Function)
+  original_vertices = vertices(g)
+  return rename_vertices(g, Dictionary(original_vertices, name_map.(original_vertices)))
+end

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -252,9 +252,9 @@ function Base.:(==)(g1::GT, g2::GT) where {GT<:AbstractNamedGraph}
 end
 
 function rename_vertices(f::Function, g::AbstractNamedGraph)
-  return set_vertices(g::AbstractNamedGraph, f.(vertices(g)))
+  return set_vertices(g, f.(vertices(g)))
 end
 
-function rename_vertices(g::AbstractNamedGraph, name_map::Dictionary)
+function rename_vertices(g::AbstractNamedGraph, name_map)
   return rename_vertices(v -> name_map[v], g)
 end

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -251,19 +251,10 @@ function Base.:(==)(g1::GT, g2::GT) where {GT<:AbstractNamedGraph}
   return true
 end
 
-function rename_vertices(g::GT, name_map::Dictionary) where {GT<:AbstractNamedGraph}
-  original_vertices = vertices(g)
-  new_vertices = getindices(name_map, original_vertices)
-  # strip type parameter to allow renaming to change the vertex type
-  base_graph_type = Base.typename(GT).wrapper
-  new_g = base_graph_type(new_vertices)
-  for e in edges(g)
-    add_edge!(new_g, rename_vertices(e, name_map))
-  end
-  return new_g
+function rename_vertices(f::Function, g::AbstractNamedGraph)
+  return set_vertices(g::AbstractNamedGraph, f.(vertices(g)))
 end
 
-function rename_vertices(g::AbstractNamedGraph, name_map::Function)
-  original_vertices = vertices(g)
-  return rename_vertices(g, Dictionary(original_vertices, name_map.(original_vertices)))
+function rename_vertices(g::AbstractNamedGraph, name_map::Dictionary)
+  return rename_vertices(v -> name_map[v], g)
 end

--- a/src/nameddimdigraph.jl
+++ b/src/nameddimdigraph.jl
@@ -66,6 +66,10 @@ function NamedDimDiGraph(parent_graph::DiGraph; dims=nothing, vertices=nothing)
   return NamedDimDiGraph(parent_graph, vertices)
 end
 
+function NamedDimDiGraph(vertices::Array)
+  return NamedDimDiGraph(DiGraph(length(vertices)); vertices)
+end
+
 NamedDimDiGraph() = NamedDimDiGraph(DiGraph())
 
 # AbstractNamedGraph required interface.

--- a/src/nameddimdigraph.jl
+++ b/src/nameddimdigraph.jl
@@ -158,3 +158,7 @@ function tree(graph::NamedDimGraph, parents::AbstractVector{T}) where {T<:Tuple}
   end
   return t
 end
+
+function set_vertices(graph::NamedDimDiGraph, vertices)
+  return NamedDimDiGraph(parent_graph(graph), vertices)
+end

--- a/src/nameddimedge.jl
+++ b/src/nameddimedge.jl
@@ -50,3 +50,5 @@ NamedDimEdge{V}(p::Pair) where {V<:Tuple} = NamedDimEdge{V}(p.first, p.second)
 # XXX: Is this a good idea? It clashes with Tuple vertices of NamedDimGraphs.
 # NamedDimEdge(t::Tuple) = NamedDimEdge(t[1], t[2])
 # NamedDimEdge{V}(t::Tuple) where {V} = NamedDimEdge(V(t[1]), V(t[2]))
+
+set_vertices(e::NamedDimEdge, src, dst) = NamedDimEdge(src, dst)

--- a/src/nameddimgraph.jl
+++ b/src/nameddimgraph.jl
@@ -76,6 +76,10 @@ function NamedDimGraph(parent_graph::Graph; dims=nothing, vertices=nothing)
   return NamedDimGraph(parent_graph, vertices)
 end
 
+function NamedDimGraph(vertices::Array)
+  return NamedDimGraph(Graph(length(vertices)); vertices)
+end
+
 NamedDimGraph() = NamedDimGraph(Graph())
 
 # AbstractNamedGraph required interface.

--- a/src/nameddimgraph.jl
+++ b/src/nameddimgraph.jl
@@ -144,3 +144,7 @@ function hvncat(
 
   return NamedDimGraph(graph_parent_graph, graph_vertices)
 end
+
+function set_vertices(graph::NamedDimGraph, vertices)
+  return NamedDimGraph(parent_graph(graph), vertices)
+end

--- a/src/namededge.jl
+++ b/src/namededge.jl
@@ -16,3 +16,5 @@ NamedEdge(t::Tuple) = NamedEdge(t[1], t[2])
 NamedEdge(p::Pair) = NamedEdge(p.first, p.second)
 NamedEdge{V}(p::Pair) where {V} = NamedEdge(V(p.first), V(p.second))
 NamedEdge{V}(t::Tuple) where {V} = NamedEdge(V(t[1]), V(t[2]))
+
+set_vertices(e::NamedEdge, src, dst) = NamedEdge(src, dst)

--- a/src/namedgraph.jl
+++ b/src/namedgraph.jl
@@ -23,3 +23,7 @@ parent_graph(graph::NamedGraph) = graph.parent_graph
 vertices(graph::NamedGraph) = graph.vertices
 vertex_to_parent_vertex(graph::NamedGraph) = graph.vertex_to_parent_vertex
 edgetype(graph::NamedGraph{V}) where {V} = NamedEdge{V}
+
+function set_vertices(graph::NamedGraph, vertices)
+  return NamedGraph(parent_graph(graph), vertices)
+end

--- a/src/namedgraph.jl
+++ b/src/namedgraph.jl
@@ -14,6 +14,10 @@ function NamedGraph(parent_graph::Graph, vertices::Vector{V}) where {V}
   return NamedGraph{V}(parent_graph, vertices)
 end
 
+function NamedGraph(vertices::Vector)
+  return NamedGraph(Graph(length(vertices)), vertices)
+end
+
 # AbstractNamedGraph required interface.
 parent_graph(graph::NamedGraph) = graph.parent_graph
 vertices(graph::NamedGraph) = graph.vertices

--- a/test/test_abstractnamedgraph.jl
+++ b/test/test_abstractnamedgraph.jl
@@ -1,0 +1,142 @@
+using Test
+using Graphs
+using MultiDimDictionaries
+using NamedGraphs
+
+@testset "AbstractNamedGraph equality" begin
+  # NamedGraph
+  g = grid((2, 2))
+  vs = ["A", "B", "C", "D"]
+  ng1 = NamedGraph(g, vs)
+  # construct same NamedGraph with different underlying structure
+  ng2 = NamedGraph(Graph(4), vs[[1, 4, 3, 2]])
+  add_edge!(ng2, "A" => "B")
+  add_edge!(ng2, "A" => "C")
+  add_edge!(ng2, "B" => "D")
+  add_edge!(ng2, "C" => "D")
+  @test NamedGraphs.parent_graph(ng1) != NamedGraphs.parent_graph(ng2)
+  @test ng1 == ng2
+  rem_edge!(ng2, "B" => "A")
+  @test ng1 != ng2
+
+  # NamedDimGraph
+  dvs = [("X", 1), ("X", 2), ("Y", 1), ("Y", 2)]
+  ndg1 = NamedDimGraph(g, dvs)
+  # construct same NamedDimGraph from different underlying structure
+  ndg2 = NamedDimGraph(Graph(4), dvs[[1, 4, 3, 2]])
+  add_edge!(ndg2, ("X", 1) => ("X", 2))
+  add_edge!(ndg2, ("X", 1) => ("Y", 1))
+  add_edge!(ndg2, ("X", 2) => ("Y", 2))
+  add_edge!(ndg2, ("Y", 1) => ("Y", 2))
+  @test NamedGraphs.parent_graph(ndg1) != NamedGraphs.parent_graph(ndg2)
+  @test ndg1 == ndg2
+  rem_edge!(ndg2, ("Y", 1) => ("X", 1))
+  @test ndg1 != ndg2
+
+  # NamedDimDiGraph
+  nddg1 = NamedDimDiGraph(DiGraph(collect(edges(g))), dvs)
+  # construct same NamedDimDiGraph from different underlying structure
+  nddg2 = NamedDimDiGraph(DiGraph(4), dvs[[1, 4, 3, 2]])
+  add_edge!(nddg2, ("X", 1) => ("X", 2))
+  add_edge!(nddg2, ("X", 1) => ("Y", 1))
+  add_edge!(nddg2, ("X", 2) => ("Y", 2))
+  add_edge!(nddg2, ("Y", 1) => ("Y", 2))
+  @test NamedGraphs.parent_graph(nddg1) != NamedGraphs.parent_graph(nddg2)
+  @test nddg1 == nddg2
+  rem_edge!(nddg2, ("X", 1) => ("Y", 1))
+  add_edge!(nddg2, ("Y", 1) => ("X", 1))
+  @test nddg1 != nddg2
+end
+
+@testset "AbstractNamedGraph vertex renaming" begin
+  g = grid((2, 2))
+  integer_names = collect(1:4)
+  string_names = ["A", "B", "C", "D"]
+  tuple_names = [("X", 1), ("X", 2), ("Y", 1), ("Y", 2)]
+  function_name = x -> reverse(x)
+
+  # NamedGraph
+  ng = NamedGraph(g, string_names)
+  # rename to integers
+  vmap_int = Dictionary(Graphs.vertices(ng), integer_names)
+  ng_int = rename_vertices(ng, vmap_int)
+  @test isa(ng_int, NamedGraph{Int})
+  @test has_vertex(ng_int, 3)
+  @test has_edge(ng_int, 1 => 2)
+  @test has_edge(ng_int, 2 => 4)
+  # rename to tuples
+  vmap_tuple = Dictionary(Graphs.vertices(ng), tuple_names)
+  ng_tuple = rename_vertices(ng, vmap_tuple)
+  @test isa(ng_tuple, NamedGraph{Tuple{String,Int}})
+  @test has_vertex(ng_tuple, ("X", 1))
+  @test has_edge(ng_tuple, ("X", 1) => ("X", 2))
+  @test has_edge(ng_tuple, ("X", 2) => ("Y", 2))
+  # rename with name map function
+  ng_function = rename_vertices(ng_tuple, function_name)
+  @test isa(ng_function, NamedGraph{Tuple{Int,String}})
+  @test has_vertex(ng_function, (1, "X"))
+  @test has_edge(ng_function, (1, "X") => (2, "X"))
+  @test has_edge(ng_function, (2, "X") => (2, "Y"))
+
+  # NamedDimGraph
+  ndg = named_grid((2, 2))
+  # rename to integers
+  vmap_int = Dictionary(Graphs.vertices(ndg), integer_names)
+  ndg_int = rename_vertices(ndg, vmap_int)
+  @test isa(ndg_int, NamedDimGraph{Tuple})
+  @test has_vertex(ndg_int, (1,))
+  @test has_edge(ndg_int, (1,) => (2,))
+  @test has_edge(ndg_int, (2,) => (4,))
+  # rename to strings
+  vmap_string = Dictionary(Graphs.vertices(ndg), string_names)
+  ndg_string = rename_vertices(ndg, vmap_string)
+  @test isa(ndg_string, NamedDimGraph{Tuple})
+  @test has_vertex(ndg_string, ("A",))
+  @test has_edge(ndg_string, ("A",) => ("B",))
+  @test has_edge(ndg_string, ("B",) => ("D",))
+  # rename to strings
+  vmap_tuple = Dictionary(Graphs.vertices(ndg), tuple_names)
+  ndg_tuple = rename_vertices(ndg, vmap_tuple)
+  @test isa(ndg_tuple, NamedDimGraph{Tuple})
+  @test has_vertex(ndg_tuple, "X", 1)
+  @test has_edge(ndg_tuple, ("X", 1) => ("X", 2))
+  @test has_edge(ndg_tuple, ("X", 2) => ("Y", 2))
+  # rename with name map function
+  ndg_function = rename_vertices(ndg_tuple, function_name)
+  @test isa(ndg_function, NamedDimGraph{Tuple})
+  @test has_vertex(ndg_function, 1, "X")
+  @test has_edge(ndg_function, (1, "X") => (2, "X"))
+  @test has_edge(ndg_function, (2, "X") => (2, "Y"))
+
+  # NamedDimDiGraph
+  nddg = NamedDimDiGraph(DiGraph(collect(edges(g))), Graphs.vertices(ndg))
+  # rename to integers
+  vmap_int = Dictionary(Graphs.vertices(nddg), integer_names)
+  nddg_int = rename_vertices(nddg, vmap_int)
+  @test isa(nddg_int, NamedDimDiGraph{Tuple})
+  @test has_vertex(nddg_int, (1,))
+  @test has_edge(nddg_int, (1,) => (2,))
+  @test has_edge(nddg_int, (2,) => (4,))
+  # rename to strings
+  vmap_string = Dictionary(Graphs.vertices(nddg), string_names)
+  nddg_string = rename_vertices(nddg, vmap_string)
+  @test isa(nddg_string, NamedDimDiGraph{Tuple})
+  @test has_vertex(nddg_string, ("A",))
+  @test has_edge(nddg_string, ("A",) => ("B",))
+  @test has_edge(nddg_string, ("B",) => ("D",))
+  @test !has_edge(nddg_string, ("D",) => ("B",))
+  # rename to strings
+  vmap_tuple = Dictionary(Graphs.vertices(nddg), tuple_names)
+  nddg_tuple = rename_vertices(nddg, vmap_tuple)
+  @test isa(nddg_tuple, NamedDimDiGraph{Tuple})
+  @test has_vertex(nddg_tuple, "X", 1)
+  @test has_edge(nddg_tuple, ("X", 1) => ("X", 2))
+  @test !has_edge(nddg_tuple, ("Y", 2) => ("X", 2))
+  # rename with name map function
+  nddg_function = rename_vertices(nddg_tuple, function_name)
+  @test isa(nddg_function, NamedDimDiGraph{Tuple})
+  @test has_vertex(nddg_function, 1, "X")
+  @test has_edge(nddg_function, (1, "X") => (2, "X"))
+  @test has_edge(nddg_function, (2, "X") => (2, "Y"))
+  @test !has_edge(nddg_function, (2, "Y") => (2, "X"))
+end

--- a/test/test_abstractnamedgraph.jl
+++ b/test/test_abstractnamedgraph.jl
@@ -72,7 +72,7 @@ end
   @test has_edge(ng_tuple, ("X", 1) => ("X", 2))
   @test has_edge(ng_tuple, ("X", 2) => ("Y", 2))
   # rename with name map function
-  ng_function = rename_vertices(ng_tuple, function_name)
+  ng_function = rename_vertices(function_name, ng_tuple)
   @test isa(ng_function, NamedGraph{Tuple{Int,String}})
   @test has_vertex(ng_function, (1, "X"))
   @test has_edge(ng_function, (1, "X") => (2, "X"))
@@ -102,7 +102,7 @@ end
   @test has_edge(ndg_tuple, ("X", 1) => ("X", 2))
   @test has_edge(ndg_tuple, ("X", 2) => ("Y", 2))
   # rename with name map function
-  ndg_function = rename_vertices(ndg_tuple, function_name)
+  ndg_function = rename_vertices(function_name, ndg_tuple)
   @test isa(ndg_function, NamedDimGraph{Tuple})
   @test has_vertex(ndg_function, 1, "X")
   @test has_edge(ndg_function, (1, "X") => (2, "X"))
@@ -133,7 +133,7 @@ end
   @test has_edge(nddg_tuple, ("X", 1) => ("X", 2))
   @test !has_edge(nddg_tuple, ("Y", 2) => ("X", 2))
   # rename with name map function
-  nddg_function = rename_vertices(nddg_tuple, function_name)
+  nddg_function = rename_vertices(function_name, nddg_tuple)
   @test isa(nddg_function, NamedDimDiGraph{Tuple})
   @test has_vertex(nddg_function, 1, "X")
   @test has_edge(nddg_function, (1, "X") => (2, "X"))

--- a/test/test_staticgraphs.jl
+++ b/test/test_staticgraphs.jl
@@ -12,7 +12,6 @@ using Random
   @test nv(ct1) == prod(dim)
   @test ne(ct1) == prod(dim) - 1
   nct1 = named_comb_tree(dim)
-  @show vertices
   for v in Graphs.vertices(nct1) # naming collising with other test
     for n in neighbors(nct1, v)
       if v[2] == 1


### PR DESCRIPTION
Some convenience `AbstractNamedGraph` functionalities that I ended up using quite often, so I though it could make sense to add them here. A summary of the (potential) additions:
- A function `rename_vertices` which allows renaming the vertices of an `AbstractNamedGraph` or `AbstractNamedEdge` given a `Function` or `Dictionary` name map. It is basically the same as the one in https://github.com/mtfishman/ITensorNetworks.jl/blob/main/examples/peps/utils.jl, with some minor adjustments to make it work for all currently existing `AbstractNamedGraph` subtypes. In particular, it seemed to make sense to allow renaming to change the vertex type for the case of `NamedGraph`.
- Constructors for all currently existing `AbstractNamedGraph` subtypes which just take a list of vertices, similar to how `Graphs.Graph(::Integer)` returns a graph with a given number of vertices and no edges.
- Equality for `AbstractNamedGraph`s, useful for checking if the underlying graph of two instances of a given data structure is the same.