### PR TITLE
Add `mincut` and related functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,16 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
+SymRCM = "286e6d88-80af-4590-acc9-0001b223b9bd"
 
 [compat]
 AbstractTrees = "0.3, 0.4"
 Dictionaries = "0.3"
 Graphs = "1"
+GraphsFlows = "0.1.1"
 SimpleTraits = "0.9"
+SplitApplyCombine = "1.2.2"
+SymRCM = "0.2.1"
 julia = "1.7"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,11 @@ version = "0.1.5"
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+GraphsFlows = "06909019-6f44-4949-96fc-b9d9aaa02889"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
 
 [compat]
 AbstractTrees = "0.3, 0.4"

--- a/examples/boundary.jl
+++ b/examples/boundary.jl
@@ -1,0 +1,19 @@
+using NamedGraphs
+using Graphs
+
+g = named_grid((5, 5))
+subgraph_vertices = [
+  (2, 2),
+  (2, 3),
+  (2, 4),
+  (3, 2),
+  (3, 3),
+  (3, 4),
+  (4, 2),
+  (4, 3),
+  (4, 4),
+]
+vs = @show boundary_vertices(g, subgraph_vertices)
+vs = @show inner_boundary_vertices(g, subgraph_vertices)
+vs = @show outer_boundary_vertices(g, subgraph_vertices)
+es = @show boundary_edges(g, subgraph_vertices)

--- a/examples/mincut.jl
+++ b/examples/mincut.jl
@@ -1,0 +1,14 @@
+using NamedGraphs
+using GraphsFlows
+
+g = NamedGraph(path_graph(4), ["A", "B", "C", "D"])
+
+part1, part2, flow = GraphsFlows.mincut(g, "A", "D")
+@show part1, part2, flow
+
+weights = Dict{Any,Float64}()
+weights["A", "B"] = 3.0
+weights["B", "C"] = 2.0
+weights["C", "D"] = 3.0
+part1, part2, flow = GraphsFlows.mincut(g, "A", "D", weights)
+@show part1, part2, flow

--- a/examples/mincut.jl
+++ b/examples/mincut.jl
@@ -3,12 +3,19 @@ using GraphsFlows
 
 g = NamedGraph(path_graph(4), ["A", "B", "C", "D"])
 
-part1, part2, flow = GraphsFlows.mincut(g, "A", "D")
-@show part1, part2, flow
+part1, part2 = mincut_partitions(g)
+@show part1, part2
+
+part1, part2 = mincut_partitions(g, "A", "D")
+@show part1, part2
 
 weights = Dict{Any,Float64}()
 weights["A", "B"] = 3.0
 weights["B", "C"] = 2.0
 weights["C", "D"] = 3.0
-part1, part2, flow = GraphsFlows.mincut(g, "A", "D", weights)
-@show part1, part2, flow
+
+part1, part2 = mincut_partitions(g, weights)
+@show part1, part2
+
+part1, part2 = mincut_partitions(g, "A", "D", weights)
+@show part1, part2

--- a/src/Graphs/abstractgraph.jl
+++ b/src/Graphs/abstractgraph.jl
@@ -23,6 +23,18 @@ end
   return digraph
 end
 
+@traitfn function directed_graph(graph::AbstractSimpleGraph::(!IsDirected))
+  digraph = directed_graph(typeof(graph))()
+  for v in vertices(graph)
+    add_vertex!(digraph)
+  end
+  for e in edges(graph)
+    add_edge!(digraph, e)
+    add_edge!(digraph, reverse(e))
+  end
+  return digraph
+end
+
 @traitfn undirected_graph(graph::::(!IsDirected)) = graph
 
 # TODO: Handle metadata in a generic way
@@ -310,4 +322,12 @@ end
   isnothing(vertices) && return nothing
   pop!(vertices)
   return [edgetype(graph)(vertex, parent_vertex(graph, vertex)) for vertex in vertices]
+end
+
+function mincut_partitions(
+  graph::AbstractGraph,
+  distmx=weights(graph),
+)
+  parts = groupfind(first(mincut(graph, distmx)))
+  return parts[1], parts[2]
 end

--- a/src/Graphs/abstractgraph.jl
+++ b/src/Graphs/abstractgraph.jl
@@ -65,6 +65,19 @@ function rename_vertices(g::AbstractGraph, name_map)
   return rename_vertices(v -> name_map[v], g)
 end
 
+function permute_vertices(graph::AbstractGraph, permutation::Vector)
+  return subgraph(graph, vertices(graph)[permutation])
+end
+
+# SymRCM.symrcm overload
+function symrcm(graph::AbstractGraph)
+  return symrcm(adjacency_matrix(graph))
+end
+
+function symrcm_permute(graph::AbstractGraph)
+  return permute_vertices(graph, symrcm(graph))
+end
+
 # Returns just the edges of a directed graph,
 # but both edge directions of an undirected graph.
 # TODO: Move to NamedGraphs.jl

--- a/src/Graphs/boundary.jl
+++ b/src/Graphs/boundary.jl
@@ -1,0 +1,54 @@
+# https://en.wikipedia.org/wiki/Boundary_(graph_theory)
+function boundary_edges(graph::AbstractGraph, subgraph_vertices; dir=:out)
+  E = edgetype(graph)
+  subgraph_vertices_set = Set(subgraph_vertices)
+  subgraph_complement = setdiff(Set(vertices(graph)), subgraph_vertices_set)
+  boundary_es = Vector{E}()
+  for subgraph_vertex in subgraph_vertices_set
+    for e in incident_edges(graph, subgraph_vertex; dir)
+      if src(e) ∈ subgraph_complement || dst(e) ∈ subgraph_complement
+        push!(boundary_es, e)
+      end
+    end
+  end
+  return boundary_es
+end
+
+# https://en.wikipedia.org/wiki/Boundary_(graph_theory)
+# See implementation of `Graphs.neighborhood_dists` as a reference.
+function inner_boundary_vertices(graph::AbstractGraph, subgraph_vertices; dir=:out)
+  V = vertextype(graph)
+  subgraph_vertices_set = Set(subgraph_vertices)
+  subgraph_complement = setdiff(Set(vertices(graph)), subgraph_vertices_set)
+  inner_boundary_vs = Vector{V}()
+  for subgraph_vertex in subgraph_vertices_set
+    for subgraph_vertex_neighbor in _neighbors(graph, subgraph_vertex; dir)
+      if subgraph_vertex_neighbor ∈ subgraph_complement
+        push!(inner_boundary_vs, subgraph_vertex)
+        break
+      end
+    end
+  end
+  return inner_boundary_vs
+end
+
+# https://en.wikipedia.org/wiki/Boundary_(graph_theory)
+# See implementation of `Graphs.neighborhood_dists` as a reference.
+function outer_boundary_vertices(graph::AbstractGraph, subgraph_vertices; dir=:out)
+  V = vertextype(graph)
+  subgraph_vertices_set = Set(subgraph_vertices)
+  subgraph_complement = setdiff(Set(vertices(graph)), subgraph_vertices_set)
+  outer_boundary_vs = Set{V}()
+  for subgraph_vertex in subgraph_vertices_set
+    for subgraph_vertex_neighbor in _neighbors(graph, subgraph_vertex; dir)
+      if subgraph_vertex_neighbor ∈ subgraph_complement
+        push!(outer_boundary_vs, subgraph_vertex_neighbor)
+      end
+    end
+  end
+  return [v for v in outer_boundary_vs]
+end
+
+function boundary_vertices(graph::AbstractGraph, subgraph_vertices; dir=:out)
+  return inner_boundary_vertices(graph, subgraph_vertices; dir)
+end

--- a/src/Graphs/shortestpaths.jl
+++ b/src/Graphs/shortestpaths.jl
@@ -1,0 +1,41 @@
+function dijkstra_parents(
+  graph::AbstractGraph,
+  vertex,
+  distmx=weights(graph)
+)
+  return dijkstra_shortest_paths(
+    graph,
+    [vertex],
+    distmx;
+    allpaths=false,
+    trackvertices=false).parents
+end
+
+function dijkstra_mst(
+  graph::AbstractGraph,
+  vertex,
+  distmx=weights(graph)
+) 
+  parents = dijkstra_shortest_paths(
+    graph,
+    [vertex],
+    distmx;
+    allpaths=false,
+    trackvertices=false).parents
+  mst = Vector{edgetype(graph)}()
+  for src in eachindex(parents)
+    dst = parents[src]
+    if src ≠ dst
+      push!(mst, edgetype(graph)(src, dst))
+    end
+  end
+  return mst
+end
+
+function dijkstra_tree(
+  graph::AbstractGraph,
+  vertex,
+  distmx=weights(graph),
+)
+  return tree(graph, dijkstra_parents(graph, vertex, distmx))
+end

--- a/src/Graphs/symrcm.jl
+++ b/src/Graphs/symrcm.jl
@@ -1,0 +1,8 @@
+# SymRCM.symrcm overload
+function symrcm(graph::AbstractGraph)
+  return symrcm(adjacency_matrix(graph))
+end
+
+function symrcm_permute(graph::AbstractGraph)
+  return permute_vertices(graph, symrcm(graph))
+end

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -87,6 +87,8 @@ import Graphs: AbstractEdge, src, dst, reverse, reverse!
 include(joinpath("Dictionaries", "dictionary.jl"))
 include(joinpath("Graphs", "abstractgraph.jl"))
 include(joinpath("Graphs", "shortestpaths.jl"))
+include(joinpath("Graphs", "boundary.jl"))
+include(joinpath("Graphs", "symrcm.jl"))
 include(joinpath("Graphs", "simplegraph.jl"))
 include(joinpath("Graphs", "generators", "staticgraphs.jl"))
 include("abstractnamededge.jl")
@@ -108,9 +110,13 @@ export NamedGraph,
   named_path_graph,
   named_path_digraph,
   # AbstractGraph
+  boundary_edges,
+  boundary_vertices,
   dijkstra_mst,
   dijkstra_parents,
   directed_graph,
+  inner_boundary_vertices,
+  outer_boundary_vertices,
   permute_vertices,
   symrcm,
   symrcm_permute,

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -1,8 +1,12 @@
 module NamedGraphs
 using AbstractTrees
 using Dictionaries
-using SimpleTraits
 using Graphs
+using GraphsFlows
+using LinearAlgebra
+using SimpleTraits
+using SparseArrays
+using SplitApplyCombine
 
 using Graphs.SimpleGraphs
 
@@ -42,6 +46,7 @@ import Graphs:
   is_weakly_connected,
   merge_vertices,
   merge_vertices!,
+  mincut,
   ne,
   neighbors,
   neighborhood,
@@ -80,9 +85,11 @@ include(joinpath("Graphs", "generators", "staticgraphs.jl"))
 include("abstractnamededge.jl")
 include("namededge.jl")
 include("abstractnamedgraph.jl")
+include("distances_and_capacities.jl")
 include("namedgraph.jl")
 include(joinpath("generators", "named_staticgraphs.jl"))
 
+# TODO: reexport Graphs.jl (except for `Graphs.contract`)
 export NamedGraph,
   NamedDiGraph,
   NamedEdge,
@@ -94,6 +101,8 @@ export NamedGraph,
   incident_edges,
   named_binary_tree,
   named_grid,
+  named_path_graph,
+  named_path_digraph,
   comb_tree,
   named_comb_tree,
   post_order_dfs_vertices,
@@ -105,6 +114,7 @@ export NamedGraph,
   indegrees,
   outdegree,
   outdegrees,
+  mincut_partitions,
   # Operations for tree-like graphs
   is_leaf,
   is_tree,
@@ -113,6 +123,9 @@ export NamedGraph,
   leaf_vertices,
   vertex_path,
   edge_path,
-  subgraph
+  subgraph,
+  # Graphs.jl
+  path_digraph,
+  path_graph
 
 end # module AbstractNamedGraphs

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -17,20 +17,24 @@ not_implemented() = error("Not implemented")
 import Base: show, eltype, copy, getindex, convert, hcat, vcat, hvncat, union, zero
 # abstractnamedgraph.jl
 import Graphs:
+  a_star,
   add_edge!,
   add_vertex!,
   add_vertices!,
   adjacency_matrix,
   all_neighbors,
+  bellman_ford_shortest_paths,
   bfs_parents,
   bfs_tree,
   blockdiag,
+  boruvka_mst,
   center,
   common_neighbors,
   connected_components,
   connected_components!,
   degree,
   degree_histogram,
+  desopo_pape_shortest_paths,
   diameter,
   dijkstra_shortest_paths,
   dst,
@@ -39,6 +43,8 @@ import Graphs:
   eccentricity,
   edges,
   edgetype,
+  enumerate_paths,
+  floyd_warshall_shortest_paths,
   has_edge,
   has_path,
   has_vertex,
@@ -50,6 +56,8 @@ import Graphs:
   is_directed,
   is_strongly_connected,
   is_weakly_connected,
+  johnson_shortest_paths,
+  kruskal_mst,
   merge_vertices,
   merge_vertices!,
   mincut,
@@ -57,27 +65,20 @@ import Graphs:
   neighbors,
   neighborhood,
   neighborhood_dists,
-  outdegree,
-  a_star,
-  bellman_ford_shortest_paths,
-  enumerate_paths,
-  desopo_pape_shortest_paths,
-  floyd_warshall_shortest_paths,
-  johnson_shortest_paths,
-  spfa_shortest_paths,
-  yen_k_shortest_paths,
-  boruvka_mst,
-  kruskal_mst,
-  prim_mst,
   nv,
+  outdegree,
   outneighbors,
+  prim_mst,
   periphery,
   radius,
   rem_vertex!,
   rem_edge!,
+  spfa_shortest_paths,
   src,
+  steiner_tree,
   tree,
-  vertices
+  vertices,
+  yen_k_shortest_paths
 import SymRCM: symrcm
 
 # abstractnamededge.jl
@@ -97,6 +98,7 @@ include("abstractnamedgraph.jl")
 include("shortestpaths.jl")
 include("distance.jl")
 include("distances_and_capacities.jl")
+include(joinpath("steiner_tree", "steiner_tree.jl"))
 include("namedgraph.jl")
 include(joinpath("generators", "named_staticgraphs.jl"))
 
@@ -112,15 +114,23 @@ export NamedGraph,
   # AbstractGraph
   boundary_edges,
   boundary_vertices,
+  child_vertices,
   dijkstra_mst,
   dijkstra_parents,
   directed_graph,
+  edge_path,
   inner_boundary_vertices,
+  is_leaf,
+  is_tree,
+  leaf_vertices,
   outer_boundary_vertices,
   permute_vertices,
+  parent_vertex,
+  subgraph,
   symrcm,
   symrcm_permute,
   undirected_graph,
+  vertex_path,
   vertextype,
   # Graphs.jl
   a_star,
@@ -152,15 +162,7 @@ export NamedGraph,
   outdegree,
   outdegrees,
   mincut_partitions,
-  weights,
-  # Operations for tree-like graphs
-  is_leaf,
-  is_tree,
-  parent_vertex,
-  child_vertices,
-  leaf_vertices,
-  vertex_path,
-  edge_path,
-  subgraph
+  steiner_tree,
+  weights
 
 end # module AbstractNamedGraphs

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -23,14 +23,18 @@ import Graphs:
   bfs_parents,
   bfs_tree,
   blockdiag,
+  center,
   common_neighbors,
   connected_components,
   connected_components!,
   degree,
   degree_histogram,
+  diameter,
+  dijkstra_shortest_paths,
   dst,
   dfs_parents,
   dfs_tree,
+  eccentricity,
   edges,
   edgetype,
   has_edge,
@@ -56,7 +60,6 @@ import Graphs:
   bellman_ford_shortest_paths,
   enumerate_paths,
   desopo_pape_shortest_paths,
-  dijkstra_shortest_paths,
   floyd_warshall_shortest_paths,
   johnson_shortest_paths,
   spfa_shortest_paths,
@@ -66,6 +69,8 @@ import Graphs:
   prim_mst,
   nv,
   outneighbors,
+  periphery,
+  radius,
   rem_vertex!,
   rem_edge!,
   src,
@@ -80,11 +85,14 @@ import Graphs: AbstractEdge, src, dst, reverse, reverse!
 
 include(joinpath("Dictionaries", "dictionary.jl"))
 include(joinpath("Graphs", "abstractgraph.jl"))
+include(joinpath("Graphs", "shortestpaths.jl"))
 include(joinpath("Graphs", "simplegraph.jl"))
 include(joinpath("Graphs", "generators", "staticgraphs.jl"))
 include("abstractnamededge.jl")
 include("namededge.jl")
 include("abstractnamedgraph.jl")
+include("shortestpaths.jl")
+include("distance.jl")
 include("distances_and_capacities.jl")
 include("namedgraph.jl")
 include(joinpath("generators", "named_staticgraphs.jl"))
@@ -93,20 +101,37 @@ include(joinpath("generators", "named_staticgraphs.jl"))
 export NamedGraph,
   NamedDiGraph,
   NamedEdge,
-  vertextype,
-  directed_graph,
-  undirected_graph,
   ⊔,
-  disjoint_union,
-  incident_edges,
   named_binary_tree,
   named_grid,
   named_path_graph,
   named_path_digraph,
+  # AbstractGraph
+  dijkstra_mst,
+  dijkstra_parents,
+  directed_graph,
+  undirected_graph,
+  vertextype,
+  # Graphs.jl
+  center,
+  diameter,
+  dijkstra_shortest_paths,
+  dijkstra_tree,
+  disjoint_union,
+  eccentricity,
+  eccentricities,
+  incident_edges,
   comb_tree,
   named_comb_tree,
+  neighborhood,
+  neighborhood_dists,
+  neighbors,
+  path_digraph,
+  path_graph,
+  periphery,
   post_order_dfs_vertices,
   post_order_dfs_edges,
+  radius,
   rename_vertices,
   degree,
   degrees,
@@ -115,6 +140,7 @@ export NamedGraph,
   outdegree,
   outdegrees,
   mincut_partitions,
+  weights,
   # Operations for tree-like graphs
   is_leaf,
   is_tree,
@@ -123,9 +149,6 @@ export NamedGraph,
   leaf_vertices,
   vertex_path,
   edge_path,
-  subgraph,
-  # Graphs.jl
-  path_digraph,
-  path_graph
+  subgraph
 
 end # module AbstractNamedGraphs

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -76,6 +76,7 @@ import Graphs:
   spfa_shortest_paths,
   src,
   steiner_tree,
+  topological_sort_by_dfs,
   tree,
   vertices,
   yen_k_shortest_paths
@@ -99,6 +100,7 @@ include("shortestpaths.jl")
 include("distance.jl")
 include("distances_and_capacities.jl")
 include(joinpath("steiner_tree", "steiner_tree.jl"))
+include(joinpath("traversals", "dfs.jl"))
 include("namedgraph.jl")
 include(joinpath("generators", "named_staticgraphs.jl"))
 

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -7,12 +7,14 @@ using LinearAlgebra
 using SimpleTraits
 using SparseArrays
 using SplitApplyCombine
+using SymRCM
 
 using Graphs.SimpleGraphs
 
 # General utility functions
 not_implemented() = error("Not implemented")
 
+import Base: show, eltype, copy, getindex, convert, hcat, vcat, hvncat, union, zero
 # abstractnamedgraph.jl
 import Graphs:
   add_edge!,
@@ -76,8 +78,7 @@ import Graphs:
   src,
   tree,
   vertices
-
-import Base: show, eltype, copy, getindex, convert, hcat, vcat, hvncat, union, zero
+import SymRCM: symrcm
 
 # abstractnamededge.jl
 import Base: Pair, Tuple, show, ==, hash, eltype, convert
@@ -110,9 +111,14 @@ export NamedGraph,
   dijkstra_mst,
   dijkstra_parents,
   directed_graph,
+  permute_vertices,
+  symrcm,
+  symrcm_permute,
   undirected_graph,
   vertextype,
   # Graphs.jl
+  a_star,
+  adjacency_matrix,
   center,
   diameter,
   dijkstra_shortest_paths,

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -497,22 +497,6 @@ end
 bfs_parents(graph::AbstractNamedGraph, vertex::Integer; kwargs...) = _bfs_parents(graph, vertex; kwargs...)
 bfs_parents(graph::AbstractNamedGraph, vertex; kwargs...) = _bfs_parents(graph, vertex; kwargs...)
 
-_dfs_tree(graph::AbstractNamedGraph, vertex; kwargs...) = tree(graph, dfs_parents(graph, vertex; kwargs...))
-dfs_tree(graph::AbstractNamedGraph, vertex::Integer; kwargs...) = _dfs_tree(graph, vertex; kwargs...)
-dfs_tree(graph::AbstractNamedGraph, vertex; kwargs...) = _dfs_tree(graph, vertex; kwargs...)
-
-# Returns a Dictionary mapping a vertex to it's parent
-# vertex in the traversal/spanning tree.
-function _dfs_parents(graph::AbstractNamedGraph, vertex; kwargs...)
-  parent_dfs_parents = dfs_parents(
-    parent_graph(graph), vertex_to_parent_vertex(graph, vertex); kwargs...
-  )
-  return Dictionary(vertices(graph), parent_vertices_to_vertices(graph, parent_dfs_parents))
-end
-# Disambiguation from Graphs.dfs_tree
-dfs_parents(graph::AbstractNamedGraph, vertex::Integer; kwargs...) = _dfs_parents(graph, vertex; kwargs...)
-dfs_parents(graph::AbstractNamedGraph, vertex; kwargs...) = _dfs_parents(graph, vertex; kwargs...)
-
 #
 # Printing
 #

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -309,21 +309,6 @@ function prim_mst(
   return parent_edges_to_edges(g, parent_mst)
 end
 
-for f in [
-  :bellman_ford_shortest_paths,
-  :desopo_pape_shortest_paths,
-  :dijkstra_shortest_paths,
-  :floyd_warshall_shortest_paths,
-  :johnson_shortest_paths,
-  :yen_k_shortest_paths,
-]
-  @eval begin
-    function $f(graph::AbstractNamedGraph, args...; kwargs...)
-      return not_implemented()
-    end
-  end
-end
-
 function add_edge!(graph::AbstractNamedGraph, edge::AbstractEdge)
   add_edge!(parent_graph(graph), edge_to_parent_edge(graph, edge))
   return graph

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -24,6 +24,8 @@ function parent_vertex_to_vertex(graph::AbstractNamedGraph, parent_vertex)
   return vertices(graph)[parent_vertex]
 end
 
+Graphs.SimpleDiGraph(graph::AbstractNamedGraph) = SimpleDiGraph(parent_graph(graph))
+
 # Convenient shorthands for using in higher order functions like `map`.
 vertex_to_parent_vertex(graph::AbstractNamedGraph) = Base.Fix1(vertex_to_parent_vertex, graph)
 parent_vertex_to_vertex(graph::AbstractNamedGraph) = Base.Fix1(parent_vertex_to_vertex, graph)
@@ -176,14 +178,6 @@ function degree_histogram(g::AbstractNamedGraph, degfn=degree)
   return hist
 end
 
-function dist_matrix_to_parent_dist_matrix(graph::AbstractNamedGraph, distmx)
-  not_implemented()
-end
-
-function dist_matrix_to_parent_dist_matrix(graph::AbstractNamedGraph, distmx::Graphs.DefaultDistance)
-  return distmx
-end
-
 function neighborhood(graph::AbstractNamedGraph, vertex, d, distmx=weights(graph); dir=:out)
   parent_distmx = dist_matrix_to_parent_dist_matrix(graph, distmx)
   parent_vertices = neighborhood(parent_graph(graph), vertex_to_parent_vertex(graph, vertex), d, parent_distmx; dir)
@@ -198,6 +192,69 @@ function neighborhood_dists(graph::AbstractNamedGraph, vertex, d, distmx=weights
   return [
     (parent_vertex_to_vertex(graph, parent_vertex), dist) for (parent_vertex, dist) in parent_vertices_and_dists
   ]
+end
+
+function _mincut(
+  graph::AbstractNamedGraph,
+  distmx,
+)
+  parent_distmx = dist_matrix_to_parent_dist_matrix(graph, distmx)
+  parent_parity, bestcut = mincut(parent_graph(graph), parent_distmx)
+  return Dictionary(vertices(graph), parent_parity), bestcut
+end
+
+function mincut(
+  graph::AbstractNamedGraph,
+  distmx=weights(graph),
+)
+  return _mincut(graph, distmx)
+end
+
+function mincut(
+  graph::AbstractNamedGraph,
+  distmx::AbstractMatrix{<:Real},
+)
+  return _mincut(graph, distmx)
+end
+
+@traitfn function GraphsFlows.mincut(
+  graph::AbstractNamedGraph::IsDirected,
+  source,
+  target,
+  capacity_matrix=DefaultNamedCapacity(graph),
+  algorithm::GraphsFlows.AbstractFlowAlgorithm=PushRelabelAlgorithm(),
+)
+  parent_part1, parent_part2, flow = GraphsFlows.mincut(
+    directed_graph(parent_graph(graph)),
+    vertex_to_parent_vertex(graph, source),
+    vertex_to_parent_vertex(graph, target),
+    dist_matrix_to_parent_dist_matrix(graph, capacity_matrix),
+    algorithm,
+  )
+  part1 = parent_vertices_to_vertices(graph, parent_part1)
+  part2 = parent_vertices_to_vertices(graph, parent_part2)
+  return (part1, part2, flow)
+end
+
+@traitfn function GraphsFlows.mincut(
+  graph::AbstractNamedGraph::(!IsDirected),
+  source,
+  target,
+  capacity_matrix=DefaultNamedCapacity(graph),
+  algorithm::GraphsFlows.AbstractFlowAlgorithm=PushRelabelAlgorithm(),
+)
+  return GraphsFlows.mincut(directed_graph(graph), source, target, _symmetrize(capacity_matrix), algorithm)
+end
+
+function mincut_partitions(
+  graph::AbstractGraph,
+  source,
+  target,
+  capacity_matrix=DefaultNamedCapacity(graph),
+  algorithm::GraphsFlows.AbstractFlowAlgorithm=PushRelabelAlgorithm(),
+)
+  part1, part2, flow = GraphsFlows.mincut(graph, source, target, capacity_matrix, algorithm)
+  return part1, part2
 end
 
 function a_star(

--- a/src/distance.jl
+++ b/src/distance.jl
@@ -35,12 +35,14 @@ end
 
 # function eccentricity(graph::AbstractNamedGraph, ::AbstractMatrix)
 
+eccentricities(graph::AbstractGraph) = eccentricities(graph, Indices(vertices(graph)))
+
 function eccentricities(
   graph::AbstractGraph,
-  vs=vertices(graph),
+  vs,
   distmx=weights(graph),
 )
-  return [eccentricity(graph, vertex, distmx) for vertex in vs]
+  return map(vertex -> eccentricity(graph, vertex, distmx), vs)
 end
 
 function _center(graph::AbstractNamedGraph, distmx)
@@ -58,8 +60,7 @@ function center(graph::AbstractNamedGraph, distmx::AbstractMatrix)
 end
 
 function _radius(graph::AbstractNamedGraph, distmx)
-  # TODO: Why does this return the parent vertices?
-  return parent_vertices_to_vertices(graph, radius(eccentricities(graph, vertices(graph), distmx)))
+  return radius(eccentricities(graph, vertices(graph), distmx))
 end
 
 function radius(graph::AbstractNamedGraph, distmx=weights(graph))
@@ -72,8 +73,7 @@ function radius(graph::AbstractNamedGraph, distmx::AbstractMatrix)
 end
 
 function _diameter(graph::AbstractNamedGraph, distmx)
-  # TODO: Why does this return the parent vertices?
-  return parent_vertices_to_vertices(graph, diameter(eccentricities(graph, vertices(graph), distmx)))
+  return diameter(eccentricities(graph, vertices(graph), distmx))
 end
 
 function diameter(graph::AbstractNamedGraph, distmx=weights(graph))

--- a/src/distance.jl
+++ b/src/distance.jl
@@ -1,0 +1,100 @@
+function _eccentricity(
+  graph::AbstractNamedGraph,
+  vertex,
+  distmx,
+)
+  e = maximum(dijkstra_shortest_paths(graph, [vertex], distmx).dists)
+  e == typemax(e) && @warn("Infinite path length detected for vertex $vertex")
+  return e
+end
+
+function eccentricity(
+  graph::AbstractNamedGraph,
+  vertex,
+  distmx=weights(graph),
+)
+  return _eccentricity(graph, vertex, distmx)
+end
+
+# Fix for ambiguity error with `AbstractGraph`
+function eccentricity(
+  graph::AbstractNamedGraph,
+  vertex::Integer,
+  distmx::AbstractMatrix{<:Real},
+)
+  return _eccentricity(graph, vertex, distmx)
+end
+
+function eccentricity(
+  graph::AbstractNamedGraph,
+  vertex,
+  distmx::AbstractMatrix,
+)
+  return _eccentricity(graph, vertex, distmx)
+end
+
+# function eccentricity(graph::AbstractNamedGraph, ::AbstractMatrix)
+
+function eccentricities(
+  graph::AbstractGraph,
+  vs=vertices(graph),
+  distmx=weights(graph),
+)
+  return [eccentricity(graph, vertex, distmx) for vertex in vs]
+end
+
+function _center(graph::AbstractNamedGraph, distmx)
+  # TODO: Why does this return the parent vertices?
+  return parent_vertices_to_vertices(graph, center(eccentricities(graph, vertices(graph), distmx)))
+end
+
+function center(graph::AbstractNamedGraph, distmx=weights(graph))
+  return _center(graph, distmx)
+end
+
+# Fix for ambiguity error with `AbstractGraph`
+function center(graph::AbstractNamedGraph, distmx::AbstractMatrix)
+  return _center(graph, distmx)
+end
+
+function _radius(graph::AbstractNamedGraph, distmx)
+  # TODO: Why does this return the parent vertices?
+  return parent_vertices_to_vertices(graph, radius(eccentricities(graph, vertices(graph), distmx)))
+end
+
+function radius(graph::AbstractNamedGraph, distmx=weights(graph))
+  return _radius(graph, distmx)
+end
+
+# Fix for ambiguity error with `AbstractGraph`
+function radius(graph::AbstractNamedGraph, distmx::AbstractMatrix)
+  return _radius(graph, distmx)
+end
+
+function _diameter(graph::AbstractNamedGraph, distmx)
+  # TODO: Why does this return the parent vertices?
+  return parent_vertices_to_vertices(graph, diameter(eccentricities(graph, vertices(graph), distmx)))
+end
+
+function diameter(graph::AbstractNamedGraph, distmx=weights(graph))
+  return _diameter(graph, distmx)
+end
+
+# Fix for ambiguity error with `AbstractGraph`
+function diameter(graph::AbstractNamedGraph, distmx::AbstractMatrix)
+  return _diameter(graph, distmx)
+end
+
+function _periphery(graph::AbstractNamedGraph, distmx)
+  # TODO: Why does this return the parent vertices?
+  return parent_vertices_to_vertices(graph, periphery(eccentricities(graph, vertices(graph), distmx)))
+end
+
+function periphery(graph::AbstractNamedGraph, distmx=weights(graph))
+  return _periphery(graph, distmx)
+end
+
+# Fix for ambiguity error with `AbstractGraph`
+function periphery(graph::AbstractNamedGraph, distmx::AbstractMatrix)
+  return _periphery(graph, distmx)
+end

--- a/src/distances_and_capacities.jl
+++ b/src/distances_and_capacities.jl
@@ -10,6 +10,9 @@ function _symmetrize(dist)
   return symmetrized_dist
 end
 
+getindex_dist_matrix(dist_matrix, I...) = dist_matrix[I...]
+getindex_dist_matrix(dist_matrix::AbstractDictionary, I...) = dist_matrix[I]
+
 function _dist_matrix_to_parent_dist_matrix(
   graph::AbstractNamedGraph,
   dist_matrix,
@@ -17,7 +20,7 @@ function _dist_matrix_to_parent_dist_matrix(
   parent_dist_matrix = spzeros(valtype(dist_matrix), nv(graph), nv(graph))
   for e in edges(graph)
     parent_e = edge_to_parent_edge(graph, e)
-    parent_dist_matrix[src(parent_e), dst(parent_e)] = dist_matrix[src(e), dst(e)]
+    parent_dist_matrix[src(parent_e), dst(parent_e)] = getindex_dist_matrix(dist_matrix, src(e), dst(e))
   end
   return parent_dist_matrix
 end

--- a/src/distances_and_capacities.jl
+++ b/src/distances_and_capacities.jl
@@ -1,0 +1,70 @@
+function _symmetrize(dist::AbstractMatrix)
+  return sparse(Symmetric(dist))
+end
+
+function _symmetrize(dist)
+  symmetrized_dist = copy(dist)
+  for k in keys(dist)
+    symmetrized_dist[reverse(k)] = dist[k]
+  end
+  return symmetrized_dist
+end
+
+function _dist_matrix_to_parent_dist_matrix(
+  graph::AbstractNamedGraph,
+  dist_matrix,
+)
+  parent_dist_matrix = spzeros(valtype(dist_matrix), nv(graph), nv(graph))
+  for e in edges(graph)
+    parent_e = edge_to_parent_edge(graph, e)
+    parent_dist_matrix[src(parent_e), dst(parent_e)] = dist_matrix[src(e), dst(e)]
+  end
+  return parent_dist_matrix
+end
+
+@traitfn function dist_matrix_to_parent_dist_matrix(
+  graph::AbstractNamedGraph::IsDirected,
+  dist_matrix,
+)
+  return _dist_matrix_to_parent_dist_matrix(graph, dist_matrix)
+end
+
+@traitfn function dist_matrix_to_parent_dist_matrix(
+  graph::AbstractNamedGraph::(!IsDirected),
+  dist_matrix,
+)
+  return _symmetrize(_dist_matrix_to_parent_dist_matrix(graph, dist_matrix))
+end
+
+function dist_matrix_to_parent_dist_matrix(graph::AbstractNamedGraph, distmx::Graphs.DefaultDistance)
+  return distmx
+end
+
+"""
+    DefaultNamedCapacity{T}
+
+Structure that returns `1` if a forward edge exists in `flow_graph`, and `0` otherwise.
+"""
+struct DefaultNamedCapacity{G<:AbstractNamedGraph,T<:Integer} <: AbstractMatrix{T}
+  flow_graph::G
+  nv::T
+end
+
+DefaultNamedCapacity(graph::AbstractNamedGraph) =
+  DefaultNamedCapacity(graph, nv(graph))
+
+function _symmetrize(dist::DefaultNamedCapacity)
+  return DefaultNamedCapacity(directed_graph(dist.flow_graph))
+end
+
+# Base.getindex(d::DefaultNamedCapacity{T}, s, t) where {T} = has_edge(d.flow_graph, s, t) ? one(T) : zero(T)
+# Base.size(d::DefaultNamedCapacity) = (Int(d.nv), Int(d.nv))
+# Base.transpose(d::DefaultNamedCapacity) = DefaultNamedCapacity(reverse(d.flow_graph))
+# Base.adjoint(d::DefaultNamedCapacity) = DefaultNamedCapacity(reverse(d.flow_graph))
+
+@traitfn function dist_matrix_to_parent_dist_matrix(
+  graph::AbstractNamedGraph::IsDirected,
+  dist_matrix::DefaultNamedCapacity,
+)
+  return GraphsFlows.DefaultCapacity(graph)
+end

--- a/src/generators/named_staticgraphs.jl
+++ b/src/generators/named_staticgraphs.jl
@@ -57,7 +57,15 @@ function named_binary_tree(
   return named_bfs_tree(simple_graph, source; source_name, child_name)
 end
 
-function named_grid(dim::Int; kwargs...)
+function named_path_graph(dim::Integer)
+  return NamedGraph(path_graph(dim))
+end
+
+function named_path_digraph(dim::Integer)
+  return NamedDiGraph(path_digraph(dim))
+end
+
+function named_grid(dim::Integer; kwargs...)
   simple_graph = grid((dim,); kwargs...)
   return NamedGraph(simple_graph)
 end

--- a/src/namedgraph.jl
+++ b/src/namedgraph.jl
@@ -78,6 +78,12 @@ function GenericNamedGraph(parent_graph::AbstractSimpleGraph, vertices)
 end
 
 #
+# Tautological constructors
+#
+
+GenericNamedGraph{V,G}(graph::GenericNamedGraph{V,G}) where {V,G} = copy(graph)
+
+#
 # Constructors from vertex names
 #
 

--- a/src/shortestpaths.jl
+++ b/src/shortestpaths.jl
@@ -1,0 +1,88 @@
+"""
+    struct NamedDijkstraState{T,U}
+
+An [`AbstractPathState`](@ref) designed for Dijkstra shortest-paths calculations.
+"""
+struct NamedDijkstraState{T<:Real,U} <: Graphs.AbstractPathState
+  parents::Dictionary{U,U}
+  dists::Vector{T}
+  predecessors::Vector{Vector{U}}
+  pathcounts::Vector{Float64}
+  closest_vertices::Vector{U}
+end
+
+function NamedDijkstraState(parents, dists, predecessors, pathcounts, closest_vertices)
+  return NamedDijkstraState(
+    parents,
+    dists,
+    convert.(Vector{eltype(parents)}, predecessors),
+    pathcounts,
+    convert(Vector{eltype(parents)}, closest_vertices),
+  )
+end
+
+function parent_path_state_to_path_state(
+  graph::AbstractNamedGraph,
+  parent_path_state::Graphs.DijkstraState,
+)
+  parent_path_state_parents = map(eachindex(parent_path_state.parents)) do i
+    pᵢ = parent_path_state.parents[i]
+    return iszero(pᵢ) ? i : pᵢ
+  end
+  return NamedDijkstraState(
+    Dictionary(vertices(graph), parent_vertices_to_vertices(graph, parent_path_state_parents)),
+    parent_path_state.dists,
+    map(x -> parent_vertices_to_vertices(graph, x), parent_path_state.predecessors),
+    parent_path_state.pathcounts,
+    parent_vertices_to_vertices(graph, parent_path_state.closest_vertices),
+  )
+end
+
+function _dijkstra_shortest_paths(
+  graph::AbstractNamedGraph,
+  srcs,
+  distmx=weights(graph);
+  allpaths=false,
+  trackvertices=false,
+)
+  parent_path_state = dijkstra_shortest_paths(
+    parent_graph(graph),
+    vertices_to_parent_vertices(graph, srcs),
+    dist_matrix_to_parent_dist_matrix(graph, distmx);
+    allpaths,
+    trackvertices,
+  )
+  return parent_path_state_to_path_state(graph, parent_path_state)
+end
+
+function dijkstra_shortest_paths(
+  graph::AbstractNamedGraph,
+  srcs,
+  distmx=weights(graph);
+  kwargs...,
+)
+  return _dijkstra_shortest_paths(graph, srcs, distmx; kwargs...)
+end
+
+function dijkstra_shortest_paths(
+  graph::AbstractNamedGraph,
+  vertex::Integer,
+  distmx::AbstractMatrix;
+  kwargs...,
+)
+  return _dijkstra_shortest_paths(graph, [vertex], distmx; kwargs...)
+end
+
+for f in [
+  :bellman_ford_shortest_paths,
+  :desopo_pape_shortest_paths,
+  :floyd_warshall_shortest_paths,
+  :johnson_shortest_paths,
+  :yen_k_shortest_paths,
+]
+  @eval begin
+    function $f(graph::AbstractNamedGraph, args...; kwargs...)
+      return not_implemented()
+    end
+  end
+end

--- a/src/shortestpaths.jl
+++ b/src/shortestpaths.jl
@@ -1,18 +1,18 @@
 """
-    struct NamedDijkstraState{T,U}
+    struct NamedDijkstraState{V,T}
 
 An [`AbstractPathState`](@ref) designed for Dijkstra shortest-paths calculations.
 """
-struct NamedDijkstraState{T<:Real,U} <: Graphs.AbstractPathState
-  parents::Dictionary{U,U}
-  dists::Vector{T}
-  predecessors::Vector{Vector{U}}
-  pathcounts::Vector{Float64}
-  closest_vertices::Vector{U}
+struct NamedDijkstraState{V,T<:Real} <: Graphs.AbstractPathState
+  parents::Dictionary{V,V}
+  dists::Dictionary{V,T}
+  predecessors::Vector{Vector{V}}
+  pathcounts::Dictionary{V,Float64}
+  closest_vertices::Vector{V}
 end
 
 function NamedDijkstraState(parents, dists, predecessors, pathcounts, closest_vertices)
-  return NamedDijkstraState(
+  return NamedDijkstraState{eltype(dists),eltype(parents)}(
     parents,
     dists,
     convert.(Vector{eltype(parents)}, predecessors),
@@ -31,9 +31,9 @@ function parent_path_state_to_path_state(
   end
   return NamedDijkstraState(
     Dictionary(vertices(graph), parent_vertices_to_vertices(graph, parent_path_state_parents)),
-    parent_path_state.dists,
+    Dictionary(vertices(graph), parent_path_state.dists),
     map(x -> parent_vertices_to_vertices(graph, x), parent_path_state.predecessors),
-    parent_path_state.pathcounts,
+    Dictionary(vertices(graph), parent_path_state.pathcounts),
     parent_vertices_to_vertices(graph, parent_path_state.closest_vertices),
   )
 end

--- a/src/steiner_tree/steiner_tree.jl
+++ b/src/steiner_tree/steiner_tree.jl
@@ -1,0 +1,12 @@
+@traitfn function steiner_tree(
+  g::AbstractNamedGraph::(!IsDirected),
+  term_vert,
+  distmx=weights(g),
+)
+  parent_tree = steiner_tree(
+    parent_graph(g),
+    vertices_to_parent_vertices(g, term_vert),
+    dist_matrix_to_parent_dist_matrix(g, distmx),
+  )
+  return typeof(g)(parent_tree, vertices(g)[1:nv(parent_tree)])
+end

--- a/src/traversals/dfs.jl
+++ b/src/traversals/dfs.jl
@@ -1,0 +1,19 @@
+@traitfn function topological_sort_by_dfs(g::AbstractNamedGraph::IsDirected)
+  return parent_vertices_to_vertices(g, topological_sort_by_dfs(parent_graph(g)))
+end
+
+_dfs_tree(graph::AbstractNamedGraph, vertex; kwargs...) = tree(graph, dfs_parents(graph, vertex; kwargs...))
+dfs_tree(graph::AbstractNamedGraph, vertex::Integer; kwargs...) = _dfs_tree(graph, vertex; kwargs...)
+dfs_tree(graph::AbstractNamedGraph, vertex; kwargs...) = _dfs_tree(graph, vertex; kwargs...)
+
+# Returns a Dictionary mapping a vertex to it's parent
+# vertex in the traversal/spanning tree.
+function _dfs_parents(graph::AbstractNamedGraph, vertex; kwargs...)
+  parent_dfs_parents = dfs_parents(
+    parent_graph(graph), vertex_to_parent_vertex(graph, vertex); kwargs...
+  )
+  return Dictionary(vertices(graph), parent_vertices_to_vertices(graph, parent_dfs_parents))
+end
+# Disambiguation from Graphs.dfs_tree
+dfs_parents(graph::AbstractNamedGraph, vertex::Integer; kwargs...) = _dfs_parents(graph, vertex; kwargs...)
+dfs_parents(graph::AbstractNamedGraph, vertex; kwargs...) = _dfs_parents(graph, vertex; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+GraphsFlows = "06909019-6f44-4949-96fc-b9d9aaa02889"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -587,4 +587,16 @@ end
       @test has_edge(st, e)
     end
   end
+  @testset "topological_sort_by_dfs" begin
+    g = NamedDiGraph(["A", "B", "C", "D", "E", "F", "G"])
+    add_edge!(g, "A" => "D")
+    add_edge!(g, "B" => "D")
+    add_edge!(g, "B" => "E")
+    add_edge!(g, "C" => "E")
+    add_edge!(g, "D" => "F")
+    add_edge!(g, "D" => "G")
+    add_edge!(g, "E" => "G")
+    t = topological_sort_by_dfs(g)
+    @test t == ["C", "B", "E", "A", "D", "G", "F"]
+  end
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -474,4 +474,17 @@ end
     @test issetequal(part1, ["C", "D"])
     @test issetequal(part2, ["A", "B"])
   end
+  @testset "dijkstra" begin
+    ## dijkstra_shortest_paths
+    ## dijkstra_tree
+    ## dijkstra_parents
+    ## dijkstra_mst
+  end
+  @testset "shortestpaths" begin
+    ## center
+    ## diameter
+    ## eccentricity
+    ## periphery
+    ## radius
+  end
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -475,16 +475,48 @@ end
     @test issetequal(part2, ["A", "B"])
   end
   @testset "dijkstra" begin
-    ## dijkstra_shortest_paths
-    ## dijkstra_tree
-    ## dijkstra_parents
-    ## dijkstra_mst
+    g = named_grid((3, 3))
+
+    srcs = [(1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2), (1, 3), (2, 3), (3, 3)]
+    dsts = [(2, 1), (2, 2), (2, 1), (2, 2), (2, 2), (2, 2), (2, 3), (2, 2), (2, 3)]
+    parents = Dictionary(srcs, dsts)
+
+    d = dijkstra_shortest_paths(g, [(2, 2)])
+    @test d.dists == Dictionary(vertices(g), [2, 1, 2, 1, 0, 1, 2, 1, 2])
+    @test d.parents == parents
+    @test d.pathcounts == Dictionary(vertices(g), [2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0])
+
+    t = dijkstra_tree(g, (2, 2))
+    @test nv(t) == 9
+    @test ne(t) == 8
+    @test issetequal(vertices(t), vertices(g))
+    for v in vertices(g)
+      if parents[v] ≠ v
+        @test has_edge(t, parents[v] => v)
+      end
+    end
+
+    p = dijkstra_parents(g, (2, 2))
+    @test p == parents
+
+    mst = dijkstra_mst(g, (2, 2))
+    @test length(mst) == 8
+    for e in mst
+      @test parents[src(e)] == dst(e)
+    end
   end
-  @testset "shortestpaths" begin
-    ## center
-    ## diameter
-    ## eccentricity
-    ## periphery
-    ## radius
+  @testset "distances" begin
+    g = named_grid((3, 3))
+    @test eccentricity(g, (1, 1)) == 4
+    @test eccentricities(g, [(1, 2), (2, 2)]) == [3, 2]
+    @test eccentricities(g, Indices([(1, 2), (2, 2)])) == Dictionary([(1, 2), (2, 2)], [3, 2])
+    @test eccentricities(g) == Dictionary(vertices(g), [4, 3, 4, 3, 2, 3, 4, 3, 4])
+    @test center(g) == [(2, 2)]
+    @test radius(g) == 2
+    @test diameter(g) == 4
+    @test issetequal(periphery(g), [(1, 1), (3, 1), (1, 3), (3, 3)])
+  end
+  @test "Bandwidth minimization" begin
+    error("Not implemented")
   end
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -1,4 +1,5 @@
 using Graphs
+using GraphsFlows
 using NamedGraphs
 using NamedGraphs.Dictionaries
 using Test
@@ -438,5 +439,39 @@ end
     @test ne(mg) == 2
     @test has_edge(mg, "B" => "A")
     @test has_edge(mg, "D" => "B")
+  end
+  @testset "mincut" begin
+    g = NamedGraph(path_graph(4), ["A", "B", "C", "D"])
+
+    part1, part2, flow = GraphsFlows.mincut(g, "A", "D")
+    @test issetequal(part1, ["A"])
+    @test issetequal(part2, ["B", "C", "D"])
+    @test flow == 1
+
+    part1, part2 = mincut_partitions(g, "A", "D")
+    @test issetequal(part1, ["A"])
+    @test issetequal(part2, ["B", "C", "D"])
+
+    part1, part2 = mincut_partitions(g)
+    @test issetequal(part1, ["B", "C", "D"])
+    @test issetequal(part2, ["A"])
+
+    weights = Dict{Tuple{String,String},Float64}()
+    weights["A", "B"] = 3
+    weights["B", "C"] = 2
+    weights["C", "D"] = 3
+
+    part1, part2, flow = GraphsFlows.mincut(g, "A", "D", weights)
+    @test issetequal(part1, ["A", "B"])
+    @test issetequal(part2, ["C", "D"])
+    @test flow == 2
+
+    part1, part2 = mincut_partitions(g, "A", "D", weights)
+    @test issetequal(part1, ["A", "B"])
+    @test issetequal(part2, ["C", "D"])
+
+    part1, part2 = mincut_partitions(g, weights)
+    @test issetequal(part1, ["C", "D"])
+    @test issetequal(part2, ["A", "B"])
   end
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -571,4 +571,20 @@ end
       end
     end
   end
+  @testset "steiner_tree" begin
+    g = named_grid((3, 5))
+    terminal_vertices = [(1, 2), (1, 4), (3, 4)]
+    st = steiner_tree(g, terminal_vertices)
+    es = [
+      (1, 2) => (1, 3),
+      (1, 3) => (1, 4),
+      (1, 4) => (2, 4),
+      (2, 4) => (3, 4),
+    ]
+    @test ne(st) == 4
+    @test nv(st) == 12
+    for e in es
+      @test has_edge(st, e)
+    end
+  end
 end


### PR DESCRIPTION
Add `AbstractNamedGraph` wrappers for `Graphs.jl` functions:

- `boundary_edges`
- `boundary_vertices`
- `center`
- `diameter`
- `dijkstra_mst`
- `dijkstra_parents`
- `dijkstra_shortest_paths`
- `dijkstra_tree`
- `eccentricity`
- `inner_boundary_vertices`
- `GraphsFlows.mincut`
- `mincut`
- `mincut_partitions`
- `outer_boundary_vertices`
- `periphery`
- `permute_vertices`
- `radius`
- `steiner_tree`
- `SymRCM.symrcm`
- `symrcm_permute`
- `topological_sort_by_dfs`

and NamedGraph constructors:

- `named_path_graph`
- `named_path_digraph`
- `named_grid(dim::Integer)`