### PR TITLE
Introduce `is_path_graph`

### DIFF
--- a/src/Base/key.jl
+++ b/src/Base/key.jl
@@ -1,0 +1,42 @@
+"""
+Key{K}
+
+A key (index) type, used for unambiguously identifying
+an object as a key or index of an indexible object
+`AbstractArray`, `AbstractDict`, etc.
+
+Useful for nested structures of indices, for example:
+```julia
+[Key([1, 2]), [Key([3, 4]), Key([5, 6])]]
+```
+which could represent partitioning a set of vertices
+```julia
+[Key([1, 2]), Key([3, 4]), Key([5, 6])]
+```
+"""
+struct Key{K}
+  I::K
+end
+Key(I...) = Key(I)
+
+show(io::IO, I::Key) = print(io, "Key(", I.I, ")")
+
+## For indexing into `AbstractArray`
+# This allows linear indexing `A[Key(2)]`.
+# Overload of `Base.to_index`.
+to_index(I::Key) = I.I
+
+# This allows cartesian indexing `A[Key(CartesianIndex(1, 2))]`.
+# Overload of `Base.to_indices`.
+to_indices(A::AbstractArray, I::Tuple{Key{<:CartesianIndex}}) = I[1].I.I
+
+# This would allow syntax like `A[Key(1, 2)]`, should we support that?
+# Overload of `Base.to_indices`.
+# to_indices(A::AbstractArray, I::Tuple{Key}) = I[1].I
+
+getindex(d::AbstractDict, I::Key) = d[I.I]
+
+# Fix ambiguity error with Base
+getindex(d::Dict, I::Key) = d[I.I]
+
+getindex(d::AbstractDictionary, I::Key) = d[I.I]

--- a/src/Graphs/abstractgraph.jl
+++ b/src/Graphs/abstractgraph.jl
@@ -180,6 +180,22 @@ function is_tree(graph::AbstractGraph)
   return (ne(graph) == nv(graph) - 1) && is_connected(graph)
 end
 
+"""
+TODO: Make this more sophisticated, check that
+only two vertices have degree 1 and none have
+degree 0, meaning it is a path/linear graph:
+
+https://en.wikipedia.org/wiki/Path_graph
+
+but not a path/linear forest:
+
+https://en.wikipedia.org/wiki/Linear_forest
+"""
+function is_path_graph(graph::AbstractGraph)
+  # Maximum degree
+  return Δ(graph) == 2
+end
+
 function out_incident_edges(graph::AbstractGraph, vertex)
   return [
     edgetype(graph)(vertex, neighbor_vertex) for

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -14,7 +14,19 @@ using Graphs.SimpleGraphs
 # General utility functions
 not_implemented() = error("Not implemented")
 
-import Base: show, eltype, copy, getindex, convert, hcat, vcat, hvncat, union, zero
+import Base:
+  convert,
+  copy,
+  eltype,
+  getindex,
+  hcat,
+  hvncat,
+  show,
+  to_index,
+  to_indices,
+  union,
+  vcat,
+  zero
 # abstractnamedgraph.jl
 import Graphs:
   a_star,
@@ -86,6 +98,7 @@ import SymRCM: symrcm
 import Base: Pair, Tuple, show, ==, hash, eltype, convert
 import Graphs: AbstractEdge, src, dst, reverse, reverse!
 
+include(joinpath("Base", "key.jl"))
 include(joinpath("Dictionaries", "dictionary.jl"))
 include(joinpath("Graphs", "abstractgraph.jl"))
 include(joinpath("Graphs", "shortestpaths.jl"))
@@ -108,6 +121,7 @@ include(joinpath("generators", "named_staticgraphs.jl"))
 export NamedGraph,
   NamedDiGraph,
   NamedEdge,
+  Key,
   ⊔,
   named_binary_tree,
   named_grid,
@@ -123,6 +137,7 @@ export NamedGraph,
   edge_path,
   inner_boundary_vertices,
   is_leaf,
+  is_path_graph,
   is_tree,
   leaf_vertices,
   outer_boundary_vertices,

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -162,13 +162,29 @@ end
 
 common_neighbors(g::AbstractNamedGraph, u, v) = intersect(neighbors(g, u), neighbors(g, v))
 
-indegree(graph::AbstractNamedGraph, vertex) = length(inneighbors(graph, vertex))
-outdegree(graph::AbstractNamedGraph, vertex) = length(outneighbors(graph, vertex))
+_indegree(graph::AbstractNamedGraph, vertex) = length(inneighbors(graph, vertex))
+_outdegree(graph::AbstractNamedGraph, vertex) = length(outneighbors(graph, vertex))
 
-@traitfn function degree(graph::AbstractNamedGraph::IsDirected, vertex)
+indegree(graph::AbstractNamedGraph, vertex) = _indegree(graph, vertex)
+outdegree(graph::AbstractNamedGraph, vertex) = _outdegree(graph, vertex)
+
+# Fix for ambiguity error with `AbstractGraph` version
+indegree(graph::AbstractNamedGraph, vertex::Integer) = _indegree(graph, vertex)
+outdegree(graph::AbstractNamedGraph, vertex::Integer) = _outdegree(graph, vertex)
+
+@traitfn function _degree(graph::AbstractNamedGraph::IsDirected, vertex)
   return indegree(graph, vertex) + outdegree(graph, vertex)
 end
-@traitfn degree(graph::AbstractNamedGraph::(!IsDirected), vertex) = indegree(graph, vertex)
+@traitfn _degree(graph::AbstractNamedGraph::(!IsDirected), vertex) = indegree(graph, vertex)
+
+function degree(graph::AbstractNamedGraph, vertex)
+  return _degree(graph::AbstractNamedGraph, vertex)
+end
+
+# Fix for ambiguity error with `AbstractGraph` version
+function degree(graph::AbstractNamedGraph, vertex::Integer)
+  return _degree(graph::AbstractNamedGraph, vertex)
+end
 
 function degree_histogram(g::AbstractNamedGraph, degfn=degree)
   hist = Dictionary{Int,Int}()

--- a/test/test_abstractgraph.jl
+++ b/test/test_abstractgraph.jl
@@ -55,6 +55,13 @@ using NamedGraphs
     [net1((1, 2), (1, 1)), net1((1, 1), (2, 1)), net1((2, 1), (2, 2))]
   @test isnothing(vertex_path(dng1, (1, 2), (3, 2)))
   @test isnothing(edge_path(dng1, (1, 2), (3, 2)))
+
+  @test is_path_graph(path_graph(4))
+  @test is_path_graph(named_path_graph(4))
+  @test is_path_graph(grid((3,)))
+  @test is_path_graph(named_grid((3,)))
+  @test !is_path_graph(grid((3, 3)))
+  @test !is_path_graph(named_grid((3, 3)))
 end
 
 @testset "Tree graph leaf vertices" begin

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -1,0 +1,24 @@
+using Dictionaries
+using NamedGraphs
+using Test
+
+@testset "Tree Base extensions" begin
+  @testset "Test Key indexing" begin
+    @test Key(1, 2) == Key((1, 2))
+
+    A = randn(2, 2)
+    @test A[1, 2] == A[Key(CartesianIndex(1, 2))]
+    @test A[2] == A[Key(2)]
+    @test_throws ErrorException A[Key(1, 2)]
+
+    A = randn(4)
+    @test A[2] == A[Key(2)]
+    @test A[2] == A[Key(CartesianIndex(2))]
+
+    A = Dict("X" => 2, "Y" => 3)
+    @test A["X"] == A[Key("X")]
+
+    A = Dictionary(["X", "Y"], [1, 2])
+    @test A["X"] == A[Key("X")]
+  end
+end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -63,6 +63,16 @@ end
     @test has_path(g, "A", "C")
     @test has_path(g, "D", "E")
     @test !has_path(g, "A", "E")
+
+    g = named_path_graph(4)
+    @test degree(g, 1) == 1
+    @test indegree(g, 1) == 1
+    @test outdegree(g, 1) == 1
+    @test degree(g, 2) == 2
+    @test indegree(g, 2) == 2
+    @test outdegree(g, 2) == 2
+    @test Δ(g) == 2
+    @test δ(g) == 1
   end
   @testset "neighborhood" begin
     g = named_grid((4, 4))


### PR DESCRIPTION
This PR adds:

- `is_path_graph` for checking if a graph is a [path/linear graph](https://en.wikipedia.org/wiki/Path_graph).
- Fixes `degree`, `indegree`, `outdegree` for integer vertex names.
- Introduces a `Key` object for unambiguous indexing of arrays, dictionaries, etc. This will help when dealing with general keys of dictionaries and vertices of NamedGraphs in nested data structures, where if the keys/vertex names are vectors it can be ambiguous whether they refer to a data structure or a key/vertex. The particular application is binary tree contraction sequences in `ITensorNetworks.jl` like `[[1, 2], 3]` which can become ambiguous if the vertex names are vectors `[1, 2], [3, 4], [5, 6]`, i.e. `[[[1, 2], [3, 4]], [5, 6]]`. Using the `Key` wrapper that sequence can be represented as `[[Key([1, 2]), Key([3, 4])], Key([5, 6])]`. @JoeyT1994