### PR TITLE
Random bfs tree

### DIFF
--- a/src/Graphs/abstractgraph.jl
+++ b/src/Graphs/abstractgraph.jl
@@ -411,3 +411,32 @@ function add_edges(g::AbstractGraph, edges)
   add_edges!(g, edges)
   return g
 end
+
+""" Do a BFS search to construct a tree, but do it with randomness to avoid generating the same tree """
+function random_bfs_tree(g::AbstractGraph, s)
+  Q = [s]
+  d = Dict([v ≠ s ? (v, Inf) : (v, 0) for v in vertices(g)])
+  visited = [s]
+  g_out = NamedDiGraph(vertices(g))
+
+  while !isempty(Q)
+    v = rand(Q)
+    setdiff!(Q, [v])
+    for vn in neighbors(g, v)
+      if(d[vn] > d[v] + 1)
+        d[vn] = d[v] + 1
+        if(vn ∉ Q)
+          if(vn ∉ visited)
+            add_edge!(g_out, v => vn)
+            push!(visited, vn)
+          end
+          push!(Q, vn)
+        end
+      end
+    end
+  end
+
+  return g_out
+
+
+end

--- a/src/Graphs/abstractgraph.jl
+++ b/src/Graphs/abstractgraph.jl
@@ -412,7 +412,7 @@ function add_edges(g::AbstractGraph, edges)
   return g
 end
 
-""" Do a BFS search to construct a tree, but do it with randomness to avoid generating the same tree """
+""" Do a BFS search to construct a tree, but do it with randomness to avoid generating the same tree. Based on Int. J. Comput. Their Appl. 15 pp 177-186 (2008). Edges will point away from source vertex s."""
 function random_bfs_tree(g::AbstractGraph, s)
   Q = [s]
   d = Dict([v ≠ s ? (v, Inf) : (v, 0) for v in vertices(g)])
@@ -437,6 +437,5 @@ function random_bfs_tree(g::AbstractGraph, s)
   end
 
   return g_out
-
 
 end

--- a/test/test_random_bfs_tree.jl
+++ b/test/test_random_bfs_tree.jl
@@ -1,0 +1,24 @@
+using Test
+using NamedGraphs
+using NamedGraphs: random_bfs_tree
+using Graphs
+using Random
+
+@testset "Random BFs Tree" begin
+  g = named_grid((10, 10))
+
+  s = (5,5)
+
+  Random.seed!(1234)
+  g_randtree1 = random_bfs_tree(g, s)
+  g_nonrandtree1 = bfs_tree(g, s)
+  Random.seed!(1434)
+  g_randtree2 = random_bfs_tree(g, s)
+  g_nonrandtree2 = bfs_tree(g, s)
+
+  @test length(edges(g_randtree1)) == length(vertices(g_randtree1)) - 1 && is_connected(g_randtree1)
+  @test length(edges(g_randtree2)) == length(vertices(g_randtree2)) - 1 && is_connected(g_randtree2)
+
+  @test edges(g_randtree1) != edges(g_randtree2)
+  @test edges(g_nonrandtree1) == edges(g_nonrandtree2)
+end

--- a/test/test_random_bfs_tree.jl
+++ b/test/test_random_bfs_tree.jl
@@ -4,7 +4,7 @@ using NamedGraphs: random_bfs_tree
 using Graphs
 using Random
 
-@testset "Random BFs Tree" begin
+@testset "Random Bfs Tree" begin
   g = named_grid((10, 10))
 
   s = (5,5)


### PR DESCRIPTION
This PR adds a function (and testing) for constructing a Breadth First Search tree for a graph but in a random manner.

The tree stems from a source vertex `s`. The edges from `s` to its neighbors are guaranteed to be in the tree but remaining edges in the tree will be random. 