### PR TITLE
Extend union to multiple named graphs

### DIFF
--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -381,6 +381,15 @@ function union(graph1::AbstractNamedGraph, graph2::AbstractNamedGraph)
   return union_graph
 end
 
+function union(
+  graph1::AbstractNamedGraph,
+  graph2::AbstractNamedGraph,
+  graph3::AbstractNamedGraph,
+  graph_rest::AbstractNamedGraph...,
+)
+  return union(union(graph1, graph2), graph3, graph_rest...)
+end
+
 function rem_vertex!(graph::AbstractNamedGraph, vertex)
   if vertex ∉ vertices(graph)
     return false

--- a/test/test_multidimgraph.jl
+++ b/test/test_multidimgraph.jl
@@ -73,6 +73,15 @@ using Test
   @test has_vertex(g, ((1, 1), "X"))
   @test has_vertex(g, ((1, 1), "Y"))
 
+  g3 = NamedGraph(grid((2, 2)); vertices=(2, 2))
+  g = disjoint_union("X" => g1, "Y" => g2, "Z" => g3)
+
+  @test nv(g) == 12
+  @test ne(g) == 12
+  @test has_vertex(g, ((1, 1), "X"))
+  @test has_vertex(g, ((1, 1), "Y"))
+  @test has_vertex(g, ((1, 1), "Z"))
+
   # TODO: Need to drop the dimensions to make these equal
   #@test issetequal(Graphs.vertices(g1), Graphs.vertices(g["X", :]))
   #@test issetequal(edges(g1), edges(g["X", :]))


### PR DESCRIPTION
Quick PR which extends the `union` function to work on multiple `NamedGraphs`, 

e.g. `union(g1::AbstractNamedGraph,  g2::AbstractNamedGraph, g3::AbstractNamedGraph)` now works