### PR TITLE
Fix bug in `copy(pg::PartitionedGraph)`

### DIFF
--- a/src/Graphs/partitionedgraphs/partitionedgraph.jl
+++ b/src/Graphs/partitionedgraphs/partitionedgraph.jl
@@ -99,7 +99,7 @@ function copy(pg::PartitionedGraph)
     copy(unpartitioned_graph(pg)),
     copy(partitioned_graph(pg)),
     copy(partitioned_vertices(pg)),
-    copy(partitionvertex(pg)),
+    copy(which_partition(pg)),
   )
 end
 

--- a/test/test_partitionedgraph.jl
+++ b/test/test_partitionedgraph.jl
@@ -27,6 +27,8 @@ using Graphs
   @test is_tree(partitioned_graph(pg))
   @test nv(pg) == nx * ny
   @test nv(partitioned_graph(pg)) == nx
+  pg_c = copy(pg)
+  @test pg_c == pg
 
   #Same partitioning but with a dictionary constructor
   partition_dict = Dictionary([first(partition) for partition in partitions], partitions)


### PR DESCRIPTION
Quick fix of a bug in `copy(pg::PartitionedGraph)` where the wrong field name was being used.
A test has been added for `copy(pg)` so the bug would be caught if it happens again.