### PR TITLE
Expand functionality and tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedGraphs"
 uuid = "678767b0-92e7-4007-89e4-4527a8725b19"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ julia> using NamedGraphs: NamedGraph
 julia> using NamedGraphs.GraphsExtensions: ⊔, disjoint_union, subgraph, rename_vertices
 
 julia> g = NamedGraph(grid((4,)), ["A", "B", "C", "D"])
-NamedGraph{String} with 4 vertices:
+NamedGraphs.NamedGraph{String} with 4 vertices:
 4-element Dictionaries.Indices{String}
  "A"
  "B"
@@ -81,7 +81,7 @@ julia> neighbors(g, "B")
  "C"
 
 julia> subgraph(g, ["A", "B"])
-NamedGraph{String} with 2 vertices:
+NamedGraphs.NamedGraph{String} with 2 vertices:
 2-element Dictionaries.Indices{String}
  "A"
  "B"
@@ -108,7 +108,7 @@ julia> dims = (2, 2)
 (2, 2)
 
 julia> g = NamedGraph(grid(dims), Tuple.(CartesianIndices(dims)))
-NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
 4-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (2, 1)
@@ -152,7 +152,7 @@ You can use vertex names to get [induced subgraphs](https://juliagraphs.org/Grap
 
 ```julia
 julia> subgraph(v -> v[1] == 1, g)
-NamedGraph{Tuple{Int64, Int64}} with 2 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 2 vertices:
 2-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (1, 2)
@@ -162,7 +162,7 @@ and 1 edge(s):
 
 
 julia> subgraph(v -> v[2] == 2, g)
-NamedGraph{Tuple{Int64, Int64}} with 2 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 2 vertices:
 2-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 2)
  (2, 2)
@@ -172,7 +172,7 @@ and 1 edge(s):
 
 
 julia> subgraph(g, [(1, 1), (2, 2)])
-NamedGraph{Tuple{Int64, Int64}} with 2 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 2 vertices:
 2-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (2, 2)
@@ -186,7 +186,7 @@ You can also take [disjoint unions](https://en.wikipedia.org/wiki/Disjoint_union
 
 ```julia
 julia> g₁ = g
-NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
 4-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (2, 1)
@@ -201,7 +201,7 @@ and 4 edge(s):
 
 
 julia> g₂ = g
-NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
 4-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (2, 1)
@@ -216,7 +216,7 @@ and 4 edge(s):
 
 
 julia> disjoint_union(g₁, g₂)
-NamedGraph{Tuple{Tuple{Int64, Int64}, Int64}} with 8 vertices:
+NamedGraphs.NamedGraph{Tuple{Tuple{Int64, Int64}, Int64}} with 8 vertices:
 8-element Dictionaries.Indices{Tuple{Tuple{Int64, Int64}, Int64}}
  ((1, 1), 1)
  ((2, 1), 1)
@@ -239,7 +239,7 @@ and 8 edge(s):
 
 
 julia> g₁ ⊔ g₂ # Same as above
-NamedGraph{Tuple{Tuple{Int64, Int64}, Int64}} with 8 vertices:
+NamedGraphs.NamedGraph{Tuple{Tuple{Int64, Int64}, Int64}} with 8 vertices:
 8-element Dictionaries.Indices{Tuple{Tuple{Int64, Int64}, Int64}}
  ((1, 1), 1)
  ((2, 1), 1)
@@ -279,7 +279,7 @@ The original graphs can be obtained from subgraphs:
 
 ```julia
 julia> rename_vertices(first, subgraph(v -> v[2] == 1, g₁ ⊔ g₂))
-NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
 4-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (2, 1)
@@ -294,7 +294,7 @@ and 4 edge(s):
 
 
 julia> rename_vertices(first, subgraph(v -> v[2] == 2, g₁ ⊔ g₂))
-NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
+NamedGraphs.NamedGraph{Tuple{Int64, Int64}} with 4 vertices:
 4-element Dictionaries.Indices{Tuple{Int64, Int64}}
  (1, 1)
  (2, 1)

--- a/src/NamedGraphs.jl
+++ b/src/NamedGraphs.jl
@@ -1,4 +1,5 @@
 module NamedGraphs
+include("lib/SimilarType/src/SimilarType.jl")
 include("lib/Keys/src/Keys.jl")
 include("lib/GraphGenerators/src/GraphGenerators.jl")
 include("lib/GraphsExtensions/src/GraphsExtensions.jl")
@@ -16,7 +17,7 @@ include("namedgraph.jl")
 include("lib/NamedGraphGenerators/src/NamedGraphGenerators.jl")
 include("lib/PartitionedGraphs/src/PartitionedGraphs.jl")
 
-export NamedGraph, NamedDiGraph, NamedEdge
+export AbstractNamedGraphs, NamedDiGraph, NamedEdge, NamedGraph
 
 using PackageExtensionCompat: @require_extensions
 function __init__()

--- a/src/decorate.jl
+++ b/src/decorate.jl
@@ -3,7 +3,7 @@ using Graphs.SimpleGraphs: SimpleGraph
 using .GraphsExtensions: GraphsExtensions, add_edges!
 
 function GraphsExtensions.decorate_graph_edges(
-  g::AbstractNamedGraph; edge_map::Function=Returns(SimpleGraph(1))
+  g::AbstractNamedGraph; edge_map::Function=Returns(NamedGraph(1))
 )
   g_dec = copy(g)
   es = edges(g_dec)
@@ -19,7 +19,7 @@ function GraphsExtensions.decorate_graph_edges(
 end
 
 function GraphsExtensions.decorate_graph_vertices(
-  g::AbstractNamedGraph; vertex_map::Function=Returns(SimpleGraph(1))
+  g::AbstractNamedGraph; vertex_map::Function=Returns(NamedGraph(1))
 )
   g_dec = copy(g)
   vs = vertices(g_dec)

--- a/src/lib/GraphGenerators/src/GraphGenerators.jl
+++ b/src/lib/GraphGenerators/src/GraphGenerators.jl
@@ -1,6 +1,7 @@
 module GraphGenerators
 using Dictionaries: Dictionary
-using Graphs: SimpleGraph, add_edge!
+using Graphs: add_edge!, dst, edges, nv, src
+using Graphs.SimpleGraphs: SimpleDiGraph, SimpleGraph, binary_tree
 
 function comb_tree(dims::Tuple)
   @assert length(dims) == 2
@@ -27,5 +28,17 @@ function comb_tree(tooth_lengths::Vector{<:Integer})
     end
   end
   return graph
+end
+
+# TODO: More efficient implementation based
+# on the implementation of `binary_tree`.
+function binary_arborescence(k::Integer)
+  graph = binary_tree(k)
+  digraph = SimpleDiGraph(nv(graph))
+  for e in edges(graph)
+    @assert dst(e) > src(e)
+    add_edge!(digraph, e)
+  end
+  return digraph
 end
 end

--- a/src/lib/GraphsExtensions/.JuliaFormatter.toml
+++ b/src/lib/GraphsExtensions/.JuliaFormatter.toml
@@ -1,0 +1,2 @@
+style = "blue"
+indent = 2

--- a/src/lib/GraphsExtensions/Project.toml
+++ b/src/lib/GraphsExtensions/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+NamedGraphs = "678767b0-92e7-4007-89e4-4527a8725b19"
+SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"

--- a/src/lib/GraphsExtensions/src/GraphsExtensions.jl
+++ b/src/lib/GraphsExtensions/src/GraphsExtensions.jl
@@ -1,5 +1,6 @@
 module GraphsExtensions
 include("abstractgraph.jl")
+include("abstracttrees.jl")
 include("boundary.jl")
 include("shortestpaths.jl")
 include("symrcm.jl")

--- a/src/lib/GraphsExtensions/src/abstracttrees.jl
+++ b/src/lib/GraphsExtensions/src/abstracttrees.jl
@@ -1,0 +1,64 @@
+# AbstractTreeGraph
+# Tree view of a graph.
+abstract type AbstractTreeGraph{V} <: AbstractGraph{V} end
+parent_graph_type(type::Type{<:AbstractTreeGraph}) = not_implemented()
+parent_graph(graph::AbstractTreeGraph) = not_implemented()
+
+Graphs.is_directed(type::Type{<:AbstractTreeGraph}) = is_directed(parent_graph_type(type))
+Graphs.edgetype(graph::AbstractTreeGraph) = edgetype(parent_graph(graph))
+function Graphs.outneighbors(graph::AbstractTreeGraph, vertex)
+  return outneighbors(parent_graph(graph), vertex)
+end
+function Graphs.inneighbors(graph::AbstractTreeGraph, vertex)
+  return inneighbors(parent_graph(graph), vertex)
+end
+Graphs.nv(graph::AbstractTreeGraph) = nv(parent_graph(graph))
+Graphs.ne(graph::AbstractTreeGraph) = ne(parent_graph(graph))
+Graphs.vertices(graph::AbstractTreeGraph) = vertices(parent_graph(graph))
+
+# AbstractTrees
+using AbstractTrees:
+  AbstractTrees, IndexNode, PostOrderDFS, PreOrderDFS, children, nodevalue
+
+# Used for tree iteration.
+# Assumes the graph is a [rooted directed tree](https://en.wikipedia.org/wiki/Tree_(graph_theory)#Rooted_tree).
+tree_graph_node(g::AbstractTreeGraph, vertex) = IndexNode(g, vertex)
+function tree_graph_node(g::AbstractGraph, vertex)
+  return tree_graph_node(TreeGraph(g), vertex)
+end
+tree_graph_node(g::AbstractGraph) = tree_graph_node(g, root_vertex(g))
+
+# Make an `AbstractTreeGraph` act as an `AbstractTree` starting at
+# the root vertex.
+AbstractTrees.children(g::AbstractTreeGraph) = children(tree_graph_node(g))
+AbstractTrees.nodevalue(g::AbstractTreeGraph) = nodevalue(tree_graph_node(g))
+
+AbstractTrees.rootindex(tree::AbstractTreeGraph) = root_vertex(tree)
+function AbstractTrees.nodevalue(tree::AbstractTreeGraph, node_index)
+  return node_index
+end
+function AbstractTrees.childindices(tree::AbstractTreeGraph, node_index)
+  return child_vertices(tree, node_index)
+end
+function AbstractTrees.parentindex(tree::AbstractTreeGraph, node_index)
+  return parent_vertex(tree, node_index)
+end
+
+# TreeGraph
+struct TreeGraph{V,G<:AbstractGraph{V}} <: AbstractTreeGraph{V}
+  graph::G
+  global function _TreeGraph(g::AbstractGraph)
+    # No check for being a tree
+    return new{vertextype(g),typeof(g)}(g)
+  end
+end
+@traitfn function TreeGraph(g::AbstractGraph::IsDirected)
+  @assert is_arborescence(g)
+  return _TreeGraph(g)
+end
+@traitfn function TreeGraph(g::AbstractGraph::(!IsDirected))
+  @assert is_tree(g)
+  return _TreeGraph(g)
+end
+parent_graph(graph::TreeGraph) = getfield(graph, :graph)
+parent_graph_type(type::Type{<:TreeGraph}) = fieldtype(type, :graph)

--- a/src/lib/GraphsExtensions/src/simplegraph.jl
+++ b/src/lib/GraphsExtensions/src/simplegraph.jl
@@ -1,3 +1,11 @@
+using Graphs.SimpleGraphs: AbstractSimpleGraph
+
+# https://github.com/JuliaGraphs/Graphs.jl/issues/365
+function graph_from_vertices(graph_type::Type{<:AbstractSimpleGraph}, vertices)
+  @assert vertices == Base.OneTo(length(vertices))
+  return graph_type(length(vertices))
+end
+
 using Graphs.SimpleGraphs: SimpleDiGraph, SimpleGraph
 
 directed_graph_type(G::Type{<:SimpleGraph}) = SimpleDiGraph{vertextype(G)}

--- a/src/lib/GraphsExtensions/test/Project.toml
+++ b/src/lib/GraphsExtensions/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+NamedGraphs = "678767b0-92e7-4007-89e4-4527a8725b19"

--- a/src/lib/GraphsExtensions/test/runtests.jl
+++ b/src/lib/GraphsExtensions/test/runtests.jl
@@ -1,0 +1,285 @@
+@eval module $(gensym())
+using AbstractTrees:
+  IndexNode,
+  Leaves,
+  PostOrderDFS,
+  childindices,
+  children,
+  nodevalue,
+  nodevalues,
+  parent,
+  parentindex,
+  rootindex
+using Dictionaries: Dictionary, Indices
+using Graphs:
+  add_edge!,
+  edges,
+  edgetype,
+  inneighbors,
+  is_cyclic,
+  is_directed,
+  ne,
+  nv,
+  outneighbors,
+  rem_edge!,
+  vertices
+using Graphs.SimpleGraphs:
+  SimpleDiGraph, SimpleEdge, SimpleGraph, grid, path_digraph, path_graph
+using NamedGraphs: NamedGraph
+using NamedGraphs.GraphsExtensions:
+  TreeGraph,
+  ⊔,
+  add_edge,
+  add_edges,
+  add_edges!,
+  all_edges,
+  degrees,
+  directed_graph,
+  directed_graph_type,
+  disjoint_union,
+  indegrees,
+  is_arborescence,
+  is_ditree,
+  is_path_graph,
+  is_self_loop,
+  outdegrees,
+  permute_vertices,
+  rem_edge,
+  rem_edges,
+  rem_edges!,
+  rename_vertices,
+  subgraph,
+  tree_graph_node,
+  undirected_graph,
+  undirected_graph_type,
+  vertextype
+using Test: @test, @test_broken, @testset
+
+@testset "NamedGraphs.GraphsExtensions" begin
+  # is_self_loop
+  @test is_self_loop(SimpleEdge(1, 1))
+  @test !is_self_loop(SimpleEdge(1, 2))
+  @test is_self_loop(1 => 1)
+  @test !is_self_loop(1 => 2)
+
+  # directed_graph_type
+  @test directed_graph_type(SimpleGraph{Int}) === SimpleDiGraph{Int}
+  @test directed_graph_type(SimpleGraph(4)) === SimpleDiGraph{Int}
+
+  # undirected_graph_type
+  @test undirected_graph_type(SimpleGraph{Int}) === SimpleGraph{Int}
+  @test undirected_graph_type(SimpleGraph(4)) === SimpleGraph{Int}
+
+  # directed_graph
+  @test directed_graph(path_digraph(4)) == path_digraph(4)
+  @test typeof(directed_graph(path_digraph(4))) === SimpleDiGraph{Int}
+  g = path_graph(4)
+  dig = directed_graph(g)
+  @test typeof(dig) === SimpleDiGraph{Int}
+  @test nv(dig) == 4
+  @test ne(dig) == 6
+  @test issetequal(
+    edges(dig), edgetype(dig).([1 => 2, 2 => 1, 2 => 3, 3 => 2, 3 => 4, 4 => 3])
+  )
+
+  # undirected_graph
+  @test undirected_graph(path_graph(4)) == path_graph(4)
+  @test typeof(undirected_graph(path_graph(4))) === SimpleGraph{Int}
+  dig = path_digraph(4)
+  g = undirected_graph(dig)
+  @test typeof(g) === SimpleGraph{Int}
+  @test g == path_graph(4)
+
+  # vertextype
+  for f in (path_graph, path_digraph)
+    for vtype in (Int, UInt64)
+      @test vertextype(f(vtype(4))) === vtype
+      @test vertextype(typeof(f(vtype(4)))) === vtype
+    end
+  end
+
+  # rename_vertices
+  vs = ["a", "b", "c", "d"]
+  for g in (
+    rename_vertices(v -> vs[v], path_graph(4)),
+    rename_vertices(path_graph(4), Dict(eachindex(vs) .=> vs)),
+  )
+    @test nv(g) == 4
+    @test ne(g) == 3
+    @test issetequal(vertices(g), vs)
+    @test issetequal(edges(g), edgetype(g).(["a" => "b", "b" => "c", "c" => "d"]))
+    @test g isa NamedGraph
+  end
+
+  # permute_vertices
+  g = path_graph(4)
+  @test_broken permute_vertices(g, [2, 1, 4, 3])
+
+  # all_edges
+  g = path_graph(4)
+  @test issetequal(
+    all_edges(g), edgetype(g).([1 => 2, 2 => 1, 2 => 3, 3 => 2, 3 => 4, 4 => 3])
+  )
+  g = path_digraph(4)
+  @test issetequal(all_edges(g), edgetype(g).([1 => 2, 2 => 3, 3 => 4]))
+
+  # subgraph
+  g = subgraph(path_graph(4), 2:4)
+  @test nv(g) == 3
+  @test ne(g) == 2
+  # TODO: Should this preserve vertex names by
+  # converting to `NamedGraph` if indexed by
+  # something besides `Base.OneTo`?
+  @test vertices(g) == 1:3
+  @test issetequal(edges(g), edgetype(g).([1 => 2, 2 => 3]))
+  @test subgraph(v -> v ∈ 2:4, path_graph(4)) == g
+
+  # degrees
+  @test degrees(path_graph(4)) == [1, 2, 2, 1]
+  @test degrees(path_graph(4), 2:4) == [2, 2, 1]
+  @test degrees(path_digraph(4)) == [1, 2, 2, 1]
+  @test degrees(path_digraph(4), 2:4) == [2, 2, 1]
+  @test degrees(path_graph(4), Indices(2:4)) == Dictionary(2:4, [2, 2, 1])
+
+  # indegrees
+  @test indegrees(path_graph(4)) == [1, 2, 2, 1]
+  @test indegrees(path_graph(4), 2:4) == [2, 2, 1]
+  @test indegrees(path_digraph(4)) == [0, 1, 1, 1]
+  @test indegrees(path_digraph(4), 2:4) == [1, 1, 1]
+
+  # outdegrees
+  @test outdegrees(path_graph(4)) == [1, 2, 2, 1]
+  @test outdegrees(path_graph(4), 2:4) == [2, 2, 1]
+  @test outdegrees(path_digraph(4)) == [1, 1, 1, 0]
+  @test outdegrees(path_digraph(4), 2:4) == [1, 1, 0]
+
+  # TreeGraph
+  # Binary tree:
+  #       
+  #      7
+  #     / \
+  #    /   \
+  #   5     6
+  #  / \   / \
+  # 1   2 3   4
+  #
+  # with vertex 6 as root.
+  g = SimpleDiGraph(7)
+  add_edge!(g, 5 => 1)
+  add_edge!(g, 5 => 2)
+  add_edge!(g, 7 => 5)
+  add_edge!(g, 6 => 7)
+  add_edge!(g, 6 => 3)
+  add_edge!(g, 6 => 4)
+  @test is_arborescence(g)
+  @test is_ditree(g)
+  g′ = copy(g)
+  add_edge!(g′, 5 => 6)
+  @test !is_arborescence(g′)
+  @test !is_ditree(g′)
+  t = TreeGraph(g)
+  @test is_directed(t)
+  @test ne(t) == 6
+  @test nv(t) == 7
+  @test vertices(t) == 1:7
+  @test issetequal(outneighbors(t, 6), [3, 4, 7])
+  @test isempty(inneighbors(t, 6))
+  @test only(inneighbors(t, 5)) == 7
+  @test edgetype(t) == SimpleEdge{Int}
+  @test vertextype(t) == Int
+  @test tree_graph_node(g, 5) == IndexNode(t, 5)
+  @test rootindex(t) == 6
+  @test issetequal(childindices(t, 6), [3, 4, 7])
+  @test issetequal(childindices(t, 7), [5])
+  @test isempty(childindices(t, 2))
+  @test isnothing(parentindex(t, 6))
+  @test parentindex(t, 3) == 6
+  @test parentindex(t, 5) == 7
+  @test IndexNode(t) == IndexNode(t, 6)
+  @test tree_graph_node(g) == tree_graph_node(g, 6)
+  dfs_g = collect(nodevalues(PostOrderDFS(tree_graph_node(g, 6))))
+  @test length(dfs_g) == 7
+  @test issetequal(dfs_g[1:4], 1:4)
+  @test dfs_g[5:7] == [5, 7, 6]
+  @test issetequal(nodevalue.(children(tree_graph_node(g, 5))), 1:2)
+  @test isempty(children(tree_graph_node(g, 1)))
+  @test issetequal(nodevalue.(Leaves(tree_graph_node(g))), 1:4)
+  @test nodevalue(parent(tree_graph_node(g, 5))) == 7
+
+  # disjoint_union, ⊔
+  g1 = path_graph(3)
+  g2 = path_graph(3)
+  for g in (
+    disjoint_union(g1, g2),
+    disjoint_union([g1, g2]),
+    disjoint_union([1 => g1, 2 => g2]),
+    disjoint_union(Dictionary([1, 2], [g1, g2])),
+    g1 ⊔ g2,
+    (1 => g1) ⊔ (2 => g2),
+  )
+    @test nv(g) == 6
+    @test ne(g) == 4
+    @test issetequal(vertices(g), [(1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2)])
+  end
+  for g in (
+    disjoint_union("x" => g1, "y" => g2),
+    disjoint_union(["x" => g1, "y" => g2]),
+    disjoint_union(Dictionary(["x", "y"], [g1, g2])),
+    ("x" => g1) ⊔ ("y" => g2),
+  )
+    @test nv(g) == 6
+    @test ne(g) == 4
+    @test issetequal(
+      vertices(g), [(1, "x"), (2, "x"), (3, "x"), (1, "y"), (2, "y"), (3, "y")]
+    )
+  end
+
+  # is_path_graph
+  g = path_graph(4)
+  @test is_path_graph(g)
+  g = grid((3, 2))
+  @test !is_path_graph(g)
+
+  # TODO:
+  # - is_leaf_vertex
+  # - is_root_vertex
+  # - is_rooted
+  # - root_vertex
+  # - parent_vertex
+
+  # add_edge
+  g = SimpleGraph(4)
+  add_edge!(g, 1 => 2)
+  @test add_edge(SimpleGraph(4), 1 => 2) == g
+
+  # add_edges
+  @test add_edges(SimpleGraph(4), [1 => 2, 2 => 3, 3 => 4]) == path_graph(4)
+
+  # add_edges!
+  g = SimpleGraph(4)
+  add_edges!(g, [1 => 2, 2 => 3, 3 => 4])
+  @test g == path_graph(4)
+
+  # rem_edge
+  g = path_graph(4)
+  # https://github.com/JuliaGraphs/Graphs.jl/issues/364
+  rem_edge!(g, 2, 3)
+  @test rem_edge(path_graph(4), 2 => 3) == g
+
+  # rem_edges
+  g = path_graph(4)
+  # https://github.com/JuliaGraphs/Graphs.jl/issues/364
+  rem_edge!(g, 2, 3)
+  rem_edge!(g, 3, 4)
+  @test rem_edges(path_graph(4), [2 => 3, 3 => 4]) == g
+
+  # rem_edges!
+  g = path_graph(4)
+  # https://github.com/JuliaGraphs/Graphs.jl/issues/364
+  rem_edge!(g, 2, 3)
+  rem_edge!(g, 3, 4)
+  g′ = path_graph(4)
+  rem_edges!(g′, [2 => 3, 3 => 4])
+  @test g′ == g
+end
+end

--- a/src/lib/SimilarType/src/SimilarType.jl
+++ b/src/lib/SimilarType/src/SimilarType.jl
@@ -1,0 +1,4 @@
+module SimilarType
+similar_type(object) = similar_type(typeof(object))
+similar_type(type::Type) = type
+end

--- a/src/namedgraph.jl
+++ b/src/namedgraph.jl
@@ -62,12 +62,14 @@ function Graphs.rem_vertex!(graph::GenericNamedGraph, vertex)
 end
 
 function GraphsExtensions.rename_vertices(f::Function, g::GenericNamedGraph)
-  # TODO: Could be `set_vertices(g, f.(g.parent_vertex_to_vertex))`.
+  # TODO: Could be implemented as `set_vertices(g, f.(g.parent_vertex_to_vertex))`.
   return GenericNamedGraph(g.parent_graph, f.(g.parent_vertex_to_vertex))
 end
 
 function GraphsExtensions.rename_vertices(f::Function, g::AbstractSimpleGraph)
-  return rename_vertices(f, GenericNamedGraph(g))
+  return error(
+    "Can't rename the vertices of a graph of type `$(typeof(g)) <: AbstractSimpleGraph`, try converting to a named graph.",
+  )
 end
 
 function GraphsExtensions.convert_vertextype(V::Type, graph::GenericNamedGraph)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
-using NamedGraphs
-using Test
-
+@eval module $(gensym())
+using Test: @testset
 test_path = joinpath(@__DIR__)
-
 test_files = filter(
   file -> startswith(file, "test_") && endswith(file, ".jl"), readdir(test_path)
 )
@@ -12,4 +10,5 @@ test_files = filter(
     println("Running test $(file_path)")
     include(file_path)
   end
+end
 end

--- a/test/test_abstractgraph.jl
+++ b/test/test_abstractgraph.jl
@@ -2,7 +2,7 @@
 using Graphs: binary_tree, dfs_tree, edgetype, grid, path_graph
 using NamedGraphs.GraphGenerators: comb_tree
 using NamedGraphs.GraphsExtensions:
-  is_leaf,
+  is_leaf_vertex,
   is_path_graph,
   edge_path,
   leaf_vertices,
@@ -83,21 +83,21 @@ end
 @testset "Tree graph leaf vertices" begin
   # undirected trees
   g = comb_tree((3, 2))
-  @test is_leaf(g, 4)
-  @test !is_leaf(g, 1)
+  @test is_leaf_vertex(g, 4)
+  @test !is_leaf_vertex(g, 1)
   @test issetequal(leaf_vertices(g), [4, 5, 6])
 
   ng = named_comb_tree((3, 2))
-  @test is_leaf(ng, (1, 2))
-  @test is_leaf(ng, (2, 2))
-  @test !is_leaf(ng, (1, 1))
+  @test is_leaf_vertex(ng, (1, 2))
+  @test is_leaf_vertex(ng, (2, 2))
+  @test !is_leaf_vertex(ng, (1, 1))
   @test issetequal(leaf_vertices(ng), [(1, 2), (2, 2), (3, 2)])
 
   # directed trees
   dng = dfs_tree(ng, (2, 2))
-  @test is_leaf(dng, (1, 2))
-  @test !is_leaf(dng, (2, 2))
-  @test !is_leaf(dng, (1, 1))
+  @test is_leaf_vertex(dng, (1, 2))
+  @test !is_leaf_vertex(dng, (2, 2))
+  @test !is_leaf_vertex(dng, (1, 1))
   @test issetequal(leaf_vertices(dng), [(1, 2), (3, 2)])
 end
 end

--- a/test/test_abstractnamedgraph.jl
+++ b/test/test_abstractnamedgraph.jl
@@ -63,14 +63,14 @@ end
   ng = NamedGraph(g, string_names)
   # rename to integers
   vmap_int = Dictionary(vertices(ng), integer_names)
-  ng_int = rename_vertices(ng, vmap_int)
+  ng_int = rename_vertices(v -> vmap_int[v], ng)
   @test isa(ng_int, NamedGraph{Int})
   @test has_vertex(ng_int, 3)
   @test has_edge(ng_int, 1 => 2)
   @test has_edge(ng_int, 2 => 4)
   # rename to tuples
   vmap_tuple = Dictionary(vertices(ng), tuple_names)
-  ng_tuple = rename_vertices(ng, vmap_tuple)
+  ng_tuple = rename_vertices(v -> vmap_tuple[v], ng)
   @test isa(ng_tuple, NamedGraph{Tuple{String,Int}})
   @test has_vertex(ng_tuple, ("X", 1))
   @test has_edge(ng_tuple, ("X", 1) => ("X", 2))
@@ -86,7 +86,7 @@ end
   ndg = named_grid((2, 2))
   # rename to integers
   vmap_int = Dictionary(vertices(ndg), integer_names)
-  ndg_int = rename_vertices(ndg, vmap_int)
+  ndg_int = rename_vertices(v -> vmap_int[v], ndg)
   @test isa(ndg_int, NamedGraph{Int})
   @test has_vertex(ndg_int, 1)
   @test has_edge(ndg_int, 1 => 2)
@@ -94,7 +94,7 @@ end
   @test length(a_star(ndg_int, 1, 4)) == 2
   # rename to strings
   vmap_string = Dictionary(vertices(ndg), string_names)
-  ndg_string = rename_vertices(ndg, vmap_string)
+  ndg_string = rename_vertices(v -> vmap_string[v], ndg)
   @test isa(ndg_string, NamedGraph{String})
   @test has_vertex(ndg_string, "A")
   @test has_edge(ndg_string, "A" => "B")
@@ -102,7 +102,7 @@ end
   @test length(a_star(ndg_string, "A", "D")) == 2
   # rename to strings
   vmap_tuple = Dictionary(vertices(ndg), tuple_names)
-  ndg_tuple = rename_vertices(ndg, vmap_tuple)
+  ndg_tuple = rename_vertices(v -> vmap_tuple[v], ndg)
   @test isa(ndg_tuple, NamedGraph{Tuple{String,Int}})
   @test has_vertex(ndg_tuple, ("X", 1))
   @test has_edge(ndg_tuple, ("X", 1) => ("X", 2))
@@ -120,14 +120,14 @@ end
   nddg = NamedDiGraph(DiGraph(collect(edges(g))), vertices(ndg))
   # rename to integers
   vmap_int = Dictionary(vertices(nddg), integer_names)
-  nddg_int = rename_vertices(nddg, vmap_int)
+  nddg_int = rename_vertices(v -> vmap_int[v], nddg)
   @test isa(nddg_int, NamedDiGraph{Int})
   @test has_vertex(nddg_int, 1)
   @test has_edge(nddg_int, 1 => 2)
   @test has_edge(nddg_int, 2 => 4)
   # rename to strings
   vmap_string = Dictionary(vertices(nddg), string_names)
-  nddg_string = rename_vertices(nddg, vmap_string)
+  nddg_string = rename_vertices(v -> vmap_string[v], nddg)
   @test isa(nddg_string, NamedDiGraph{String})
   @test has_vertex(nddg_string, "A")
   @test has_edge(nddg_string, "A" => "B")
@@ -135,7 +135,7 @@ end
   @test !has_edge(nddg_string, "D" => "B")
   # rename to strings
   vmap_tuple = Dictionary(vertices(nddg), tuple_names)
-  nddg_tuple = rename_vertices(nddg, vmap_tuple)
+  nddg_tuple = rename_vertices(v -> vmap_tuple[v], nddg)
   @test isa(nddg_tuple, NamedDiGraph{Tuple{String,Int}})
   @test has_vertex(nddg_tuple, ("X", 1))
   @test has_edge(nddg_tuple, ("X", 1) => ("X", 2))

--- a/test/test_namedgraphgenerators.jl
+++ b/test/test_namedgraphgenerators.jl
@@ -1,6 +1,6 @@
 @eval module $(gensym())
 using Graphs: edges, neighbors, vertices
-using NamedGraphs.GraphsExtensions: is_path_graph
+using NamedGraphs.GraphsExtensions: is_cycle_graph
 using NamedGraphs.NamedGraphGenerators:
   named_hexagonal_lattice_graph, named_triangular_lattice_graph
 using Test: @test, @testset
@@ -9,8 +9,7 @@ using Test: @test, @testset
   g = named_hexagonal_lattice_graph(1, 1)
 
   #Should just be 1 hexagon
-  # TODO: Replace with `is_cycle_graph`.
-  @test is_path_graph(g)
+  @test is_cycle_graph(g)
 
   #Check consistency with the output of hexagonal_lattice_graph(7,7) in networkx
   g = named_hexagonal_lattice_graph(7, 7)
@@ -25,8 +24,7 @@ using Test: @test, @testset
   g = named_triangular_lattice_graph(1, 1)
 
   #Should just be 1 triangle
-  # TODO: Replace with `is_cycle_graph`.
-  @test is_path_graph(g)
+  @test is_cycle_graph(g)
 
   g = named_hexagonal_lattice_graph(2, 1)
   dims = maximum(vertices(g))

--- a/test/test_namedgraphgenerators.jl
+++ b/test/test_namedgraphgenerators.jl
@@ -9,6 +9,7 @@ using Test: @test, @testset
   g = named_hexagonal_lattice_graph(1, 1)
 
   #Should just be 1 hexagon
+  # TODO: Replace with `is_cycle_graph`.
   @test is_path_graph(g)
 
   #Check consistency with the output of hexagonal_lattice_graph(7,7) in networkx
@@ -24,6 +25,7 @@ using Test: @test, @testset
   g = named_triangular_lattice_graph(1, 1)
 
   #Should just be 1 triangle
+  # TODO: Replace with `is_cycle_graph`.
   @test is_path_graph(g)
 
   g = named_hexagonal_lattice_graph(2, 1)


### PR DESCRIPTION
This is in conjunction with https://github.com/mtfishman/ITensorNetworks.jl/pull/159 and https://github.com/mtfishman/DataGraphs.jl/pull/31.

It moves some general graph functionality from ITensorNetworks into this package, along with expanding tests of the `GraphsExtensions` submodule.

TODO:
- [x] ~~Change the design of `parent_graph`, `vertex_to_parent_vertex`, etc. using a type like [OrderedCollections.OrderedSet](https://juliacollections.github.io/OrderedCollections.jl/dev/ordered_containers/#OrderedSets), [AcceleratedArrays.jl](https://github.com/andyferris/AcceleratedArrays.jl), or [OrdinalIndexing.jl](https://github.com/jishnub/OrdinalIndexing.jl). A better name for `parent_graph` would be `ordinal_graph`, and `ordinal_vertices`/`ordinal_vertex` could refer to the integer vertices of the `ordinal_graph`. `vertices` could be an ordered `AbstractVector` of the named vertices with fast lookup of the vertex positions in the `ordinal_graph`.~~ (Leaving for future work.)
- [x] Update https://github.com/mtfishman/ITensorNetworks.jl/pull/159 as needed to confirm the changes here are appropriate for ITensorNetworks.jl.