### PR TITLE
Eulerian paths

### DIFF
--- a/src/lib/GraphsExtensions/src/GraphsExtensions.jl
+++ b/src/lib/GraphsExtensions/src/GraphsExtensions.jl
@@ -6,6 +6,7 @@ include("neighbors.jl")
 include("shortestpaths.jl")
 include("symrcm.jl")
 include("partitioning.jl")
+include("traversal.jl")
 include("trees_and_forests.jl")
 include("simplegraph.jl")
 end

--- a/src/lib/GraphsExtensions/src/traversal.jl
+++ b/src/lib/GraphsExtensions/src/traversal.jl
@@ -1,0 +1,42 @@
+
+#Given a graph, traverse it from start vertex to end vertex, covering each edge exactly once.
+#Complexity is O(length(edges(g)))
+function eulerian_path(g::AbstractGraph, start_vertex, end_vertex)
+  #Conditions on g for the required path to exist
+  if start_vertex != end_vertex
+    @assert isodd(degree(g, start_vertex) % 2)
+    @assert isodd(degree(g, end_vertex) % 2)
+    @assert all(
+      x -> iseven(x), degrees(g, setdiff(vertices(g), [start_vertex, end_vertex]))
+    )
+  else
+    @assert all(x -> iseven(x), degrees(g, vertices(g)))
+  end
+
+  path = []
+  stack = []
+  current_vertex = end_vertex
+  g_modified = copy(g)
+  while !isempty(stack) || !iszero(degree(g_modified, current_vertex))
+    if iszero(degree(g_modified, current_vertex))
+      append!(path, current_vertex)
+      last_vertex = pop!(stack)
+      current_vertex = last_vertex
+    else
+      append!(stack, current_vertex)
+      vn = first(neighbors(g_modified, current_vertex))
+      rem_edge!(g_modified, edgetype(g_modified)(current_vertex, vn))
+      current_vertex = vn
+    end
+  end
+
+  append!(path, current_vertex)
+
+  return edgetype(g_modified)[
+    edgetype(g_modified)(path[i], path[i + 1]) for i in 1:(length(path) - 1)
+  ]
+end
+
+function eulerian_cycle(g::AbstractGraph, start_vertex)
+  return eulerian_path(g, start_vertex, start_vertex)
+end

--- a/src/lib/GraphsExtensions/test/runtests.jl
+++ b/src/lib/GraphsExtensions/test/runtests.jl
@@ -52,6 +52,9 @@ using NamedGraphs.GraphsExtensions:
   directed_graph_type,
   disjoint_union,
   distance_to_leaves,
+  _eulerian_cycle,
+  eulerian_cycle,
+  eulerian_path,
   has_edges,
   has_leaf_neighbor,
   has_vertices,
@@ -68,6 +71,7 @@ using NamedGraphs.GraphsExtensions:
   is_rooted,
   is_self_loop,
   leaf_vertices,
+  make_all_degrees_even,
   minimum_distance_to_leaves,
   next_nearest_neighbors,
   non_leaf_edges,
@@ -588,5 +592,15 @@ using Test: @test, @test_broken, @test_throws, @testset
   @test only(vertices_at_distance(g, 1, L - 1)) == L
   @test only(next_nearest_neighbors(g, 1)) == 3
   @test issetequal(vertices_at_distance(g, 5, 3), [2, 8])
+
+  #Eulerian paths
+  g = path_graph(L)
+  path = eulerian_path(g, 1, L)
+  @test path == [edgetype(g)(i, i + 1) for i in 1:(L - 1)]
+
+  g = add_edge(g, L => 1)
+  cycle = eulerian_cycle(g, 1)
+  correct_cycle = vcat([edgetype(g)(i, i + 1) for i in 1:(L - 1)], [edgetype(g)(L, 1)])
+  @test cycle == correct_cycle || reverse(reverse.(cycle)) == correct_cycle
 end
 end


### PR DESCRIPTION
This PR adds algorithms for finding `Eulieran` paths and `Eulerian` cycles for the `AbstractGraph` type.

An Eulerian path is a path from a source vertex to a target vertex which traverses each edge in the graph exactly once. In order to have an Eulerian path the source and target vertex must be of odd degree and all other vertices of even degree.
An Eulerian cycle is a path from a source vertex back to itself which traverses each edge in the graph exactly once. In order to have an Eulerian cycle all vertices of the graph must be of even degree.

See: https://en.wikipedia.org/wiki/Eulerian_path for more info.

If such a cycle/ path exists for a graph `g`, the algorithm implemented here will find it in `O(M)` where `M = length(edges(g))` time.

@mtfishman I think this could be a good base for coming up with a good sweeping plan for DMRG.

1. If a graph has an Eulerian cycle then a reasonable one/two-site sweep plan is simply `eulerian_cycle(g)` for the first half sweep and then `reverse(eulerian_cycle(g))` for the second half. 
2. If the graph doesn't have an Eulerian cycle (because it has vertices of odd degree) then it seems reasonable to: **i)** add "dummy" edges whilst minimising `dist(g_original, src(e), dst(e))` until all its vertices have even degree, then **ii)** construct a corresponding Eulerian cycle starting at one of the extremal vertices of the original graph `g` and finally **iii)** if doing a two-site sweep plan, remove any dummy edges from the cycle

Consider:
An open boundary 1D chain of `L` sites. Then a single edge will be added `1 => L` to make all the vertices of even degree and the Eulerian cycle will simply start at site `1/L` and flow round to site `L/1` of the chain and then backwards as is done in typical DMRG.