### PR TITLE
Add functions `subgraph_edges` and `forest_cover_edge_sequence`; refine `similar_graph` interface.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedGraphs"
 uuid = "678767b0-92e7-4007-89e4-4527a8725b19"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -1,4 +1,4 @@
-using .GraphsExtensions: GraphsExtensions, directed_graph, incident_edges,
+using .GraphsExtensions: GraphsExtensions, all_edges, directed_graph, incident_edges,
     partition_vertices, rem_edges, rem_edges!, rem_vertices, rename_vertices,
     similar_simplegraph, subgraph
 using Dictionaries: set!
@@ -52,56 +52,39 @@ GraphsExtensions.convert_vertextype(::Type{V}, g::AbstractNamedGraph{V}) where {
 GraphsExtensions.convert_vertextype(::Type, g::AbstractNamedGraph) = not_implemented()
 
 function similar_graph(graph::AbstractGraph)
-    return similar_graph(graph, copy(vertices(graph)), copy(edges(graph)))
-end
-
-function similar_graph(graph::AbstractGraph, vertices)
-    new_edge_type = convert_vertextype(eltype(vertices), edgetype(graph))
-    return similar_graph(graph, vertices, new_edge_type[])
+    newgraph = similar_graph(graph, copy(vertices(graph)))
+    add_edges!(newgraph, edges(graph))
+    return newgraph
 end
 
 # Construct `GenericNamedGraph` as a fallback.
 @traitfn function similar_graph(
-        ::AbstractGraph::(!IsDirected),
-        vertices,
-        edges
+        graph::AbstractGraph::(!IsDirected),
+        vertices
     )
     V = eltype(vertices)
-    graph = add_edges!(NamedGraph{V}(vertices), edges)
-    return graph
+    return NamedGraph{V}(vertices)
 end
 @traitfn function similar_graph(
-        ::AbstractGraph::IsDirected,
-        vertices,
-        edges
+        graph::AbstractGraph::IsDirected,
+        vertices
     )
     V = eltype(vertices)
-    graph = add_edges!(NamedDiGraph{V}(vertices), edges)
-    return graph
+    return NamedDiGraph{V}(vertices)
 end
 
 # Passing a type as a first argument attempts to call a constructor. Should be overloaded
 # if the constructor doesnt exist for a given `AbstractGraph` concrete type.
-similar_graph(T::Type{<:AbstractGraph}) = T()
-similar_graph(T::Type{<:AbstractGraph}, vertices) = T(vertices)
-function similar_graph(T::Type{<:AbstractGraph}, vertices, edges)
-    graph = similar_graph(T, vertices)
-    add_edges!(graph, edges)
-    return graph
-end
+similar_graph(T::Type{<:AbstractGraph}, vertices = vertextype(T)[]) = T(vertices)
 
 # If `T <: AbstractSimpleGraph`, then we defer to `GraphsExtensions.similar_simplegraph`.
-function similar_graph(T::Type{<:AbstractSimpleGraph}, vertices = 0, edges = [])
-    return similar_simplegraph(T, vertices, edges)
+function similar_graph(T::Type{<:AbstractSimpleGraph}, vertices = 0)
+    return similar_simplegraph(T, vertices)
 end
 
 edgeless_graph(graph::AbstractGraph) = rem_edges(graph, edges(graph))
-# The intention is this will fail if `T` cannot be edgeless.
-edgeless_graph(T::Type{<:AbstractGraph}, vertices) = similar_graph(T, vertices, [])
 
 empty_graph(graph::AbstractGraph) = rem_vertices(graph, vertices(graph))
-# The intention is this will fail if `T` cannot be empty.
-empty_graph(T::Type{<:AbstractGraph}) = similar_graph(T, vertextype(T)[], [])
 
 Base.copy(graph::AbstractNamedGraph) = copyto!(similar_graph(graph), graph)
 
@@ -413,12 +396,12 @@ function Graphs.has_path(
 end
 
 function Base.union(graph1::AbstractNamedGraph, graph2::AbstractNamedGraph)
-    union_graph = promote_type(typeof(graph1), typeof(graph2))()
+    union_graph_type = promote_type(typeof(graph1), typeof(graph2))
+
     union_vertices = union(vertices(graph1), vertices(graph2))
 
-    for v in union_vertices
-        add_vertex!(union_graph, v)
-    end
+    union_graph = similar_graph(union_graph_type, union_vertices)
+
     for e in edges(graph1)
         add_edge!(union_graph, e)
     end
@@ -448,7 +431,9 @@ Graphs.is_connected(graph::AbstractNamedGraph) = is_connected(position_graph(gra
 Graphs.is_cyclic(graph::AbstractNamedGraph) = is_cyclic(position_graph(graph))
 
 @traitfn function Base.reverse(graph::AbstractNamedGraph::IsDirected)
-    return similar_graph(graph, vertices, map(reverse, collect(edges(graph))))
+    newgraph = edgeless_graph(graph)
+    add_edges!(newgraph, map(reverse, edges(graph)))
+    return newgraph
 end
 
 # This wont be the most efficient way for a given graph type.
@@ -603,15 +588,15 @@ end
 # TODO: Implement an edgelist version
 function induced_subgraph_from_vertices(graph::AbstractGraph, subvertices)
     subgraph = similar_graph(graph, collect(subvertices))
-    subvertices_set = Set(subvertices)
-    for src in subvertices
-        for dst in outneighbors(graph, src)
-            if dst in subvertices_set && has_edge(graph, src, dst)
-                add_edge!(subgraph, src => dst)
-            end
-        end
-    end
+    add_edges!(subgraph, subgraph_edges(graph, subvertices))
     return subgraph, nothing
+end
+
+function subgraph_edges(graph::AbstractGraph, subvertices)
+    subvertices_set = Set(subvertices)
+    return Iterators.filter(edges(graph)) do edge
+        return src(edge) in subvertices_set && dst(edge) in subvertices_set
+    end
 end
 
 function GraphsExtensions.edge_subgraph(graph::AbstractNamedGraph, edges)
@@ -631,16 +616,14 @@ function edge_subgraph_namedgraph(graph, edgelist)
     return g
 end
 
-@traitfn function GraphsExtensions.directed_graph(graph::AbstractGraph::(!IsDirected))
-    digraph = similar_graph(directed_graph_type(graph), vertices(graph), edges(graph))
-    for e in edges(graph)
-        add_edge!(digraph, reverse(e))
-    end
+@traitfn function GraphsExtensions.directed_graph(graph::AbstractNamedGraph::(!IsDirected))
+    digraph = similar_graph(directed_graph_type(graph), vertices(graph))
+    add_edges!(digraph, all_edges(graph))
     return digraph
 end
 
-@traitfn function GraphsExtensions.undirected_graph(graph::AbstractGraph::IsDirected)
-    undigraph = edgeless_graph(undirected_graph_type(graph), vertices(graph))
+@traitfn function GraphsExtensions.undirected_graph(graph::AbstractNamedGraph::IsDirected)
+    undigraph = similar_graph(undirected_graph_type(graph), vertices(graph))
     for e in edges(graph)
         has_edge(undigraph, e) && continue
         add_edge!(undigraph, e)

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -647,3 +647,8 @@ end
     end
     return undigraph
 end
+
+function GraphsExtensions.forest_cover_edge_sequence(graph::AbstractNamedGraph; kwargs...)
+    dummy_graph = add_edges!(NamedGraph(vertices(graph)), edges(graph))
+    return GraphsExtensions.forest_cover_edge_sequence(dummy_graph; kwargs...)
+end

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -647,3 +647,16 @@ end
     end
     return undigraph
 end
+
+# This function will return a similar tree graph for graphs that have e.g. immutable edges.
+function similar_tree(graph::AbstractGraph, vertices, edges)
+    tree = NamedGraph(vertices)
+    add_edges!(tree, edges)
+    is_tree(tree) || throw(ArgumentError("The edges provided do not form a tree."))
+    return tree
+end
+
+# This function will return a similar tree graph for graphs that have e.g. immutable edges.
+function similar_tree(graph::AbstractSimpleGraph, vertices, edges)
+    return GraphsExtensions.similar_simpletree(graph, vertices, edges)
+end

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -647,16 +647,3 @@ end
     end
     return undigraph
 end
-
-# This function will return a similar tree graph for graphs that have e.g. immutable edges.
-function similar_tree(graph::AbstractGraph, vertices, edges)
-    tree = NamedGraph(vertices)
-    add_edges!(tree, edges)
-    is_tree(tree) || throw(ArgumentError("The edges provided do not form a tree."))
-    return tree
-end
-
-# This function will return a similar tree graph for graphs that have e.g. immutable edges.
-function similar_tree(graph::AbstractSimpleGraph, vertices, edges)
-    return GraphsExtensions.similar_simpletree(graph, vertices, edges)
-end

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -75,7 +75,8 @@ end
 
 # Passing a type as a first argument attempts to call a constructor. Should be overloaded
 # if the constructor doesnt exist for a given `AbstractGraph` concrete type.
-similar_graph(T::Type{<:AbstractGraph}, vertices = vertextype(T)[]) = T(vertices)
+similar_graph(T::Type{<:AbstractGraph}) = similar_graph(T, vertextype(T)[])
+similar_graph(T::Type{<:AbstractGraph}, vertices) = T(vertices)
 
 # If `T <: AbstractSimpleGraph`, then we defer to `GraphsExtensions.similar_simplegraph`.
 function similar_graph(T::Type{<:AbstractSimpleGraph}, vertices = 0)

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -396,11 +396,8 @@ function Graphs.has_path(
 end
 
 function Base.union(graph1::AbstractNamedGraph, graph2::AbstractNamedGraph)
-    union_graph_type = promote_type(typeof(graph1), typeof(graph2))
-
     union_vertices = union(vertices(graph1), vertices(graph2))
-
-    union_graph = similar_graph(union_graph_type, union_vertices)
+    union_graph = similar_graph(graph1, union_vertices)
 
     for e in edges(graph1)
         add_edge!(union_graph, e)

--- a/src/abstractnamedgraph.jl
+++ b/src/abstractnamedgraph.jl
@@ -52,7 +52,7 @@ GraphsExtensions.convert_vertextype(::Type{V}, g::AbstractNamedGraph{V}) where {
 GraphsExtensions.convert_vertextype(::Type, g::AbstractNamedGraph) = not_implemented()
 
 function similar_graph(graph::AbstractGraph)
-    newgraph = similar_graph(graph, copy(vertices(graph)))
+    newgraph = similar_graph(graph, vertices(graph))
     add_edges!(newgraph, edges(graph))
     return newgraph
 end

--- a/src/lib/GraphsExtensions/src/abstractgraph.jl
+++ b/src/lib/GraphsExtensions/src/abstractgraph.jl
@@ -29,36 +29,29 @@ convert_vertextype(::Type, ::Type{<:AbstractGraph}) = not_implemented()
 # ==================================== similar_simplegraph =============================== #
 
 function similar_simplegraph(graph::AbstractGraph)
-    return similar_simplegraph(graph, vertices(graph), edges(graph))
+    newgraph = similar_simplegraph(graph, vertices(graph))
+    add_edges!(newgraph, edges(graph))
+    return newgraph
 end
 
-function similar_simplegraph(graph::AbstractGraph, vertices)
-    new_edge_type = convert_vertextype(eltype(vertices), edgetype(graph))
-    return similar_simplegraph(graph, vertices, new_edge_type[])
-end
-
-function similar_simplegraph(graph::AbstractGraph, vertices::Base.OneTo, edges)
-    return similar_simplegraph(graph, length(vertices), edges)
+function similar_simplegraph(graph::AbstractGraph, vertices::Base.OneTo)
+    return similar_simplegraph(graph, length(vertices))
 end
 # To be specialized (optional, has following fallback)
 @traitfn function similar_simplegraph(
         graph::AbstractGraph::(!IsDirected),
-        nvertices::Int,
-        edges
+        nvertices::Int
     )
     new_graph = SimpleGraph(nvertices)
-    add_edges!(new_graph, edges)
     return new_graph
 end
 
 # To be specialized (optional, has following fallback)
 @traitfn function similar_simplegraph(
         graph::AbstractGraph::IsDirected,
-        nvertices::Int,
-        edges
+        nvertices::Int
     )
     new_graph = SimpleDiGraph(nvertices)
-    add_edges!(new_graph, edges)
     return new_graph
 end
 
@@ -68,10 +61,6 @@ function similar_simplegraph(T::Type{<:AbstractSimpleGraph}, vertices::Base.OneT
     return similar_simplegraph(T, length(vertices))
 end
 similar_simplegraph(T::Type{<:AbstractSimpleGraph}, nvertices::Int) = T(nvertices)
-function similar_simplegraph(T::Type{<:AbstractSimpleGraph}, vertices, edges)
-    new_graph = similar_simplegraph(T, vertices)
-    return add_edges!(new_graph, edges)
-end
 
 @traitfn directed_graph(graph::::IsDirected) = graph
 @traitfn undirected_graph(graph::::(!IsDirected)) = graph

--- a/src/lib/GraphsExtensions/src/simplegraph.jl
+++ b/src/lib/GraphsExtensions/src/simplegraph.jl
@@ -28,10 +28,8 @@ directed_graph_type(G::Type{<:SimpleDiGraph}) = G
 undirected_graph_type(G::Type{<:SimpleDiGraph}) = SimpleGraph{vertextype(G)}
 
 @traitfn function directed_graph(graph::AbstractSimpleGraph::(!IsDirected))
-    digraph = similar_simplegraph(directed_graph_type(graph), vertices(graph), edges(graph))
-    for e in edges(graph)
-        add_edge!(digraph, reverse(e))
-    end
+    digraph = similar_simplegraph(directed_graph_type(graph), vertices(graph))
+    add_edges!(digraph, all_edges(graph))
     return digraph
 end
 

--- a/src/lib/GraphsExtensions/src/trees_and_forests.jl
+++ b/src/lib/GraphsExtensions/src/trees_and_forests.jl
@@ -62,5 +62,18 @@ function forest_cover(g::AbstractGraph; spanning_tree = spanning_tree)
     return identity.(forests)
 end
 
+function forest_cover_edge_sequence(gi::AbstractGraph; root_vertex = default_root_vertex)
+    forests = forest_cover(g)
+    rv = edgetype(g)[]
+    for forest in forests
+        trees = [forest[Vertices(vs)] for vs in connected_components(forest)]
+        for tree in trees
+            tree_edges = post_order_dfs_edges(tree, root_vertex(tree))
+            push!(rv, vcat(tree_edges, reverse(reverse.(tree_edges)))...)
+        end
+    end
+    return rv
+end
+
 # TODO: Define in `NamedGraphs.PartitionedGraphs`.
 # forest_cover(g::PartitionedGraph; kwargs...) = not_implemented()

--- a/src/lib/GraphsExtensions/src/trees_and_forests.jl
+++ b/src/lib/GraphsExtensions/src/trees_and_forests.jl
@@ -1,5 +1,6 @@
 using .GraphsExtensions: random_bfs_tree, rem_edges, undirected_graph
-using Graphs: IsDirected, bfs_tree, connected_components, edges, edgetype
+using Graphs:
+    AbstractGraph, IsDirected, SimpleGraph, bfs_tree, connected_components, edges, edgetype
 using SimpleTraits: SimpleTraits, @traitfn, Not
 
 abstract type SpanningTreeAlgorithm end
@@ -60,6 +61,14 @@ function forest_cover(g::AbstractGraph; spanning_tree = spanning_tree)
     end
     # Narrow the element type if possible.
     return identity.(forests)
+end
+
+# This function will return a similar tree graph for graphs that have e.g. immutable edges.
+function similar_simpletree(::AbstractGraph, vertices, edges)
+    tree = similar_simplegraph(SimpleGraph, vertices)
+    add_edges!(tree, edges)
+    is_tree(tree) || throw(ArgumentError("The edges provided do not form a tree."))
+    return tree
 end
 
 # TODO: Define in `NamedGraphs.PartitionedGraphs`.

--- a/src/lib/GraphsExtensions/src/trees_and_forests.jl
+++ b/src/lib/GraphsExtensions/src/trees_and_forests.jl
@@ -1,6 +1,5 @@
 using .GraphsExtensions: random_bfs_tree, rem_edges, undirected_graph
-using Graphs:
-    AbstractGraph, IsDirected, SimpleGraph, bfs_tree, connected_components, edges, edgetype
+using Graphs: IsDirected, bfs_tree, connected_components, edges, edgetype
 using SimpleTraits: SimpleTraits, @traitfn, Not
 
 abstract type SpanningTreeAlgorithm end
@@ -61,14 +60,6 @@ function forest_cover(g::AbstractGraph; spanning_tree = spanning_tree)
     end
     # Narrow the element type if possible.
     return identity.(forests)
-end
-
-# This function will return a similar tree graph for graphs that have e.g. immutable edges.
-function similar_simpletree(::AbstractGraph, vertices, edges)
-    tree = similar_simplegraph(SimpleGraph, vertices)
-    add_edges!(tree, edges)
-    is_tree(tree) || throw(ArgumentError("The edges provided do not form a tree."))
-    return tree
 end
 
 # TODO: Define in `NamedGraphs.PartitionedGraphs`.

--- a/src/lib/GraphsExtensions/src/trees_and_forests.jl
+++ b/src/lib/GraphsExtensions/src/trees_and_forests.jl
@@ -62,11 +62,11 @@ function forest_cover(g::AbstractGraph; spanning_tree = spanning_tree)
     return identity.(forests)
 end
 
-function forest_cover_edge_sequence(gi::AbstractGraph; root_vertex = default_root_vertex)
+function forest_cover_edge_sequence(g::AbstractGraph; root_vertex = default_root_vertex)
     forests = forest_cover(g)
     rv = edgetype(g)[]
     for forest in forests
-        trees = [forest[Vertices(vs)] for vs in connected_components(forest)]
+        trees = [subgraph(forest, vs) for vs in connected_components(forest)]
         for tree in trees
             tree_edges = post_order_dfs_edges(tree, root_vertex(tree))
             push!(rv, vcat(tree_edges, reverse(reverse.(tree_edges)))...)

--- a/src/lib/GraphsExtensions/test/runtests.jl
+++ b/src/lib/GraphsExtensions/test/runtests.jl
@@ -14,9 +14,9 @@ using NamedGraphs.GraphsExtensions: TreeGraph, add_edge, add_edges, add_edges!,
     is_ditree, is_edge_arranged, is_leaf_edge, is_leaf_vertex, is_path_graph,
     is_root_vertex, is_rooted, is_self_loop, leaf_vertices, minimum_distance_to_leaves,
     next_nearest_neighbors, non_leaf_edges, outdegrees, permute_vertices, rem_edge,
-    rem_edges, rem_edges!, rename_vertices, root_vertex, similar_simplegraph, subgraph,
-    tree_graph_node, undirected_graph, undirected_graph_type, vertextype,
-    vertices_at_distance, ⊔
+    rem_edges, rem_edges!, rename_vertices, root_vertex, similar_simplegraph,
+    similar_simpletree, subgraph, tree_graph_node, undirected_graph, undirected_graph_type,
+    vertextype, vertices_at_distance, ⊔
 using NamedGraphs: NamedDiGraph, NamedEdge, NamedGraph
 using Test: @test, @test_broken, @test_throws, @testset
 
@@ -542,6 +542,13 @@ using Test: @test, @test_broken, @test_throws, @testset
     @test only(vertices_at_distance(g, 1, L - 1)) == L
     @test only(next_nearest_neighbors(g, 1)) == 3
     @test issetequal(vertices_at_distance(g, 5, 3), [2, 8])
+
+    g = path_graph(4)
+    # similar_simpletree
+    @test similar_simpletree(g, vertices(g), edges(g)) == g
+    @test similar_simpletree(g, vertices(g), edges(g)) !== g
+    g = cycle_graph(4)
+    @test_throws ArgumentError similar_simpletree(g, vertices(g), edges(g))
 
     @testset "arrange" begin
         @testset "is_arranged, is_edge_arranged" begin

--- a/src/lib/GraphsExtensions/test/runtests.jl
+++ b/src/lib/GraphsExtensions/test/runtests.jl
@@ -497,10 +497,6 @@ using Test: @test, @test_broken, @test_throws, @testset
     @test isempty(edges(similar_simplegraph(g, vertices(g))))
     @test isempty(edges(similar_simplegraph(typeof(g), vertices(g))))
 
-    @test similar_simplegraph(g, vertices(g), edges(g)) == g
-    @test similar_simplegraph(typeof(g), vertices(g), edges(g)) == g
-    @test !(similar_simplegraph(g, vertices(g), edges(g)) === g)
-
     # add_edge
     g = SimpleGraph(4)
     add_edge!(g, 1 => 2)

--- a/src/lib/GraphsExtensions/test/runtests.jl
+++ b/src/lib/GraphsExtensions/test/runtests.jl
@@ -14,9 +14,9 @@ using NamedGraphs.GraphsExtensions: TreeGraph, add_edge, add_edges, add_edges!,
     is_ditree, is_edge_arranged, is_leaf_edge, is_leaf_vertex, is_path_graph,
     is_root_vertex, is_rooted, is_self_loop, leaf_vertices, minimum_distance_to_leaves,
     next_nearest_neighbors, non_leaf_edges, outdegrees, permute_vertices, rem_edge,
-    rem_edges, rem_edges!, rename_vertices, root_vertex, similar_simplegraph,
-    similar_simpletree, subgraph, tree_graph_node, undirected_graph, undirected_graph_type,
-    vertextype, vertices_at_distance, ⊔
+    rem_edges, rem_edges!, rename_vertices, root_vertex, similar_simplegraph, subgraph,
+    tree_graph_node, undirected_graph, undirected_graph_type, vertextype,
+    vertices_at_distance, ⊔
 using NamedGraphs: NamedDiGraph, NamedEdge, NamedGraph
 using Test: @test, @test_broken, @test_throws, @testset
 
@@ -542,13 +542,6 @@ using Test: @test, @test_broken, @test_throws, @testset
     @test only(vertices_at_distance(g, 1, L - 1)) == L
     @test only(next_nearest_neighbors(g, 1)) == 3
     @test issetequal(vertices_at_distance(g, 5, 3), [2, 8])
-
-    g = path_graph(4)
-    # similar_simpletree
-    @test similar_simpletree(g, vertices(g), edges(g)) == g
-    @test similar_simpletree(g, vertices(g), edges(g)) !== g
-    g = cycle_graph(4)
-    @test_throws ArgumentError similar_simpletree(g, vertices(g), edges(g))
 
     @testset "arrange" begin
         @testset "is_arranged, is_edge_arranged" begin

--- a/src/lib/OrderedDictionaries/src/orderedindices.jl
+++ b/src/lib/OrderedDictionaries/src/orderedindices.jl
@@ -25,8 +25,6 @@ struct OrderedIndices{I} <: AbstractIndices{I}
 end
 OrderedIndices(indices) = OrderedIndices{eltype(indices)}(indices)
 
-OrderedIndices{I}(indices::OrderedIndices{I}) where {I} = copy(indices)
-
 ordered_indices(indices::OrderedIndices) = getfield(indices, :ordered_indices)
 # TODO: Better name for this?
 index_positions(indices::OrderedIndices) = getfield(indices, :index_positions)

--- a/src/namedgraph.jl
+++ b/src/namedgraph.jl
@@ -225,16 +225,12 @@ const NamedDiGraph{V} = GenericNamedGraph{V, SimpleDiGraph{Int}}
 
 function similar_graph(
         ::GenericNamedGraph{<:Any, G},
-        vertices,
-        edges
+        vertices
     ) where {G}
     V = eltype(vertices)
-    graph = similar_graph(GenericNamedGraph{V, G}, vertices, edges)
+    graph = similar_graph(GenericNamedGraph{V, G}, vertices)
     # HACK: Unsure why this annotation is needed, but some type inference fails without it.
     return graph::GenericNamedGraph{V, G}
 end
 
-function similar_graph(T::Type{<:GenericNamedGraph}, vertices, edges)
-    graph = add_edges!(T(vertices), edges)
-    return graph
-end
+similar_graph(T::Type{<:GenericNamedGraph}, vertices) = T(vertices)

--- a/src/namedgraph.jl
+++ b/src/namedgraph.jl
@@ -10,9 +10,13 @@ using Graphs: Graphs, AbstractGraph, add_edge!, add_vertex!, edgetype, has_edge,
 struct GenericNamedGraph{V, G <: AbstractSimpleGraph{Int}} <: AbstractNamedGraph{V}
     position_graph::G
     vertices::OrderedIndices{V}
-    global function _GenericNamedGraph(position_graph, vertices)
-        @assert length(vertices) == nv(position_graph)
-        return new{eltype(vertices), typeof(position_graph)}(position_graph, vertices)
+    function GenericNamedGraph{V, G}(graph, vertices) where {V, G}
+        position_graph = G(graph)
+        vertices = OrderedIndices{V}(to_vertices(position_graph, vertices))
+
+        @assert length(vertices) == nv(graph)
+
+        return new{V, G}(position_graph, vertices)
     end
 end
 
@@ -79,24 +83,6 @@ _to_vertices(::AbstractGraph, vertices) = vertices
 to_vertices(vertices) = vertices
 to_vertices(vertices::AbstractArray) = vec(vertices)
 to_vertices(vertices::Integer) = Base.OneTo(vertices)
-
-# Inner constructor
-# TODO: Is this needed?
-function GenericNamedGraph{V, G}(
-        position_graph::G, vertices::OrderedIndices{V}
-    ) where {V, G <: AbstractSimpleGraph{Int}}
-    return _GenericNamedGraph(position_graph, vertices)
-end
-
-function GenericNamedGraph{V, G}(
-        position_graph::AbstractSimpleGraph, vertices
-    ) where {V, G <: AbstractSimpleGraph{Int}}
-    return GenericNamedGraph{V, G}(
-        convert(G, position_graph), OrderedIndices{V}(
-            to_vertices(position_graph, vertices)
-        )
-    )
-end
 
 function GenericNamedGraph{V}(position_graph::AbstractSimpleGraph, vertices) where {V}
     return GenericNamedGraph{V, typeof(position_graph)}(position_graph, vertices)

--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -25,7 +25,7 @@ function namedgraph_steiner_tree(
         push!(featured_vertices, dst(named_edge))
     end
 
-    tree = similar_tree(g, featured_vertices, named_edges)
+    tree = similar_graph(g, featured_vertices, named_edges)
 
     return tree
 end

--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -25,7 +25,7 @@ function namedgraph_steiner_tree(
         push!(featured_vertices, dst(named_edge))
     end
 
-    tree = similar_graph(g, featured_vertices, named_edges)
+    tree = similar_tree(g, featured_vertices, named_edges)
 
     return tree
 end

--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -25,7 +25,8 @@ function namedgraph_steiner_tree(
         push!(featured_vertices, dst(named_edge))
     end
 
-    tree = similar_graph(g, featured_vertices, named_edges)
+    tree = NamedGraph(featured_vertices)
+    add_edges!(tree, named_edges)
 
     return tree
 end

--- a/test/test_abstractnamedgraph.jl
+++ b/test/test_abstractnamedgraph.jl
@@ -15,8 +15,8 @@ end
 
 TestGraph{V}(vertices = V[]) where {V} = TestGraph(NamedGraph(vertices))
 
-function NamedGraphs.similar_graph(g::Type{<:TestGraph}, vertices, edges)
-    return TestGraph(similar_graph(NamedGraph, vertices, edges))
+function NamedGraphs.similar_graph(g::Type{<:TestGraph}, vertices)
+    return TestGraph(similar_graph(NamedGraph, vertices))
 end
 
 Graphs.vertices(g::TestGraph) = vertices(g.graph)
@@ -24,7 +24,6 @@ Graphs.edges(g::TestGraph) = edges(g.graph)
 
 Graphs.is_directed(::Type{<:TestGraph}) = false
 
-Base.:(==)(g1::TestGraph, g2::AbstractGraph) = g1.graph == g2
 Base.:(==)(g1::TestGraph, g2::TestGraph) = g1.graph == g2.graph
 
 Graphs.edgetype(::Type{<:TestGraph{V}}) where {V} = edgetype(NamedGraph{V})
@@ -181,7 +180,7 @@ end
 
     @test similar_graph(g) isa NamedGraph
     @test similar_graph(g) == ug
-    @test !(similar_graph(g) === ug)
+    @test similar_graph(g) !== ug
 
     @test similar_graph(typeof(g)) isa typeof(g)
     @test similar_graph(typeof(g)) == typeof(g)()
@@ -192,11 +191,6 @@ end
     @test similar_graph(typeof(g), vertices(g)) == typeof(g)(vertices(g))
     @test isempty(edges(similar_graph(g, vertices(g))))
     @test isempty(edges(similar_graph(typeof(g), vertices(g))))
-
-    @test similar_graph(g, vertices(g), edges(g)) == ug
-    @test !(similar_graph(g, vertices(g), edges(g)) === ug)
-    @test similar_graph(typeof(g), vertices(g), edges(g)) == g
-    @test !(similar_graph(typeof(g), vertices(g), edges(g)) === g)
 
     @test nv(empty_graph(ug)) == 0
     @test ne(empty_graph(ug)) == 0

--- a/test/test_abstractnamedgraph.jl
+++ b/test/test_abstractnamedgraph.jl
@@ -5,8 +5,8 @@ using Graphs: Graphs, AbstractGraph, DiGraph, Graph, a_star, add_edge!, edges, e
 using NamedGraphs.GraphsExtensions: GraphsExtensions, rename_vertices
 using NamedGraphs.NamedGraphGenerators: named_grid, named_path_graph
 using NamedGraphs: NamedGraphs, AbstractNamedGraph, NamedDiGraph, NamedGraph,
-    edgeless_graph, empty_graph, position_graph, similar_graph, similar_tree
-using Test: @test, @test_throws, @testset
+    edgeless_graph, empty_graph, position_graph, similar_graph
+using Test: @test, @testset
 
 struct TestGraph{V} <: AbstractNamedGraph{V}
     graph::NamedGraph{V}
@@ -175,7 +175,7 @@ end
     @test !has_edge(nddg_function, (2, "Y") => (2, "X"))
 end
 
-@testset "AbstractNamedGraph `similar_graph/tree`" begin
+@testset "AbstractNamedGraph `similar_graph`" begin
     ug = named_path_graph(4)
     g = TestGraph(ug)
 
@@ -207,12 +207,6 @@ end
     # Make sure the TestGraph is unchanged.
     @test nv(g) == 4
     @test ne(g) == 3
-
-    @test similar_tree(ug, vertices(ug), edges(ug)) == ug
-    @test similar_tree(ug, vertices(ug), edges(ug)) !== ug
-    @test similar_tree(g, vertices(g), edges(g)) == ug
-    ug_loopy = add_edge!(copy(ug), 1 => 4)
-    @test_throws ArgumentError similar_tree(ug, vertices(ug), edges(ug_loopy))
 end
 
 end

--- a/test/test_abstractnamedgraph.jl
+++ b/test/test_abstractnamedgraph.jl
@@ -5,8 +5,8 @@ using Graphs: Graphs, AbstractGraph, DiGraph, Graph, a_star, add_edge!, edges, e
 using NamedGraphs.GraphsExtensions: GraphsExtensions, rename_vertices
 using NamedGraphs.NamedGraphGenerators: named_grid, named_path_graph
 using NamedGraphs: NamedGraphs, AbstractNamedGraph, NamedDiGraph, NamedGraph,
-    edgeless_graph, empty_graph, position_graph, similar_graph
-using Test: @test, @testset
+    edgeless_graph, empty_graph, position_graph, similar_graph, similar_tree
+using Test: @test, @test_throws, @testset
 
 struct TestGraph{V} <: AbstractNamedGraph{V}
     graph::NamedGraph{V}
@@ -175,7 +175,7 @@ end
     @test !has_edge(nddg_function, (2, "Y") => (2, "X"))
 end
 
-@testset "AbstractNamedGraph `similar_graph`" begin
+@testset "AbstractNamedGraph `similar_graph/tree`" begin
     ug = named_path_graph(4)
     g = TestGraph(ug)
 
@@ -207,6 +207,12 @@ end
     # Make sure the TestGraph is unchanged.
     @test nv(g) == 4
     @test ne(g) == 3
+
+    @test similar_tree(ug, vertices(ug), edges(ug)) == ug
+    @test similar_tree(ug, vertices(ug), edges(ug)) !== ug
+    @test similar_tree(g, vertices(g), edges(g)) == ug
+    ug_loopy = add_edge!(copy(ug), 1 => 4)
+    @test_throws ArgumentError similar_tree(ug, vertices(ug), edges(ug_loopy))
 end
 
 end


### PR DESCRIPTION
This PR does the following:
1. removes the `similar_graph` methods that took edges as an argument (these were removed in DataGraphs.jl , but not in NamedGraphs.jl yet.), 
2. adds the `subgraph_edges` function.
3. adds the `forest_cover_edge_sequence` function, that is currently sitting out-of-place in ITensorNetworksNext.jl, into NamedGraphs.GraphsExtensions.