### PR TITLE
Add named_cycle_graph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedGraphs"
 uuid = "678767b0-92e7-4007-89e4-4527a8725b19"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/src/lib/NamedGraphGenerators/src/NamedGraphGenerators.jl
+++ b/src/lib/NamedGraphGenerators/src/NamedGraphGenerators.jl
@@ -1,7 +1,7 @@
 module NamedGraphGenerators
 
-export NamedGridGraph, named_binary_tree, named_comb_tree, named_grid,
-    named_hexagonal_lattice_graph, named_path_digraph, named_path_graph,
+export NamedGridGraph, named_binary_tree, named_comb_tree, named_cycle_graph,
+    named_grid, named_hexagonal_lattice_graph, named_path_digraph, named_path_graph,
     named_triangular_lattice_graph
 
 include("graphgenerators.jl")

--- a/src/lib/NamedGraphGenerators/src/graphgenerators.jl
+++ b/src/lib/NamedGraphGenerators/src/graphgenerators.jl
@@ -2,8 +2,8 @@ using ..GraphGenerators: comb_tree
 using ..GraphsExtensions: add_edges!, rem_vertices!
 using ..NamedGraphs: NamedGraph
 using Graphs.SimpleGraphs: AbstractSimpleGraph
-using Graphs: IsDirected, bfs_tree, binary_tree, grid, inneighbors, merge_vertices, nv,
-    outneighbors, path_graph, rem_vertex!
+using Graphs: IsDirected, bfs_tree, binary_tree, cycle_graph, grid, inneighbors,
+    merge_vertices, nv, outneighbors, path_graph, rem_vertex!
 using SimpleTraits: SimpleTraits, @traitfn, Not
 
 ## TODO: Bring this back in some form?
@@ -73,6 +73,10 @@ end
 
 function named_path_graph(dim::Integer)
     return NamedGraph(path_graph(dim))
+end
+
+function named_cycle_graph(dim::Integer)
+    return NamedGraph(cycle_graph(dim))
 end
 
 function named_path_digraph(dim::Integer)

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -19,6 +19,7 @@ using Test: @test, @testset
             :NamedGridGraph,
             :named_binary_tree,
             :named_comb_tree,
+            :named_cycle_graph,
             :named_grid,
             :named_hexagonal_lattice_graph,
             :named_path_digraph,

--- a/test/test_namedgraphgenerators.jl
+++ b/test/test_namedgraphgenerators.jl
@@ -4,8 +4,8 @@ using Graphs: a_star, add_edge!, add_vertex!, degree, edges, edgetype, has_edge,
     is_directed, ne, neighbors, nv, rem_edge!, rem_vertex!, vertices
 using NamedGraphs.GraphsExtensions: is_cycle_graph, vertextype
 using NamedGraphs.NamedGraphGenerators: NamedGridGraph, grid_ndims, grid_size,
-    is_directed_grid, ishypertorus, named_grid, named_hexagonal_lattice_graph,
-    named_triangular_lattice_graph
+    is_directed_grid, ishypertorus, named_cycle_graph, named_grid,
+    named_hexagonal_lattice_graph, named_triangular_lattice_graph
 using NamedGraphs: NamedEdge
 using Test: @test, @test_throws, @testset
 
@@ -47,6 +47,14 @@ using Test: @test, @test_throws, @testset
     g = named_triangular_lattice_graph(6, 6; periodic = true)
     degree_dist = [length(neighbors(g, v)) for v in vertices(g)]
     @test all(d -> d == 6, degree_dist)
+end
+
+@testset "named_cycle_graph" begin
+    g = named_cycle_graph(4)
+    @test nv(g) == 4
+    @test ne(g) == 4
+    @test issetequal(vertices(g), 1:4)
+    @test is_cycle_graph(g)
 end
 
 @testset "NamedGridGraph" begin


### PR DESCRIPTION
## Summary

Adds `named_cycle_graph(n)`, which returns the cycle graph on `n` vertices as a `NamedGraph`, mirroring the existing `named_path_graph`.