### PR TITLE
Fix bug where `rem_edge!` on `PartitionedGraph` would not remove edge when final edge in quotient edge.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedGraphs"
 uuid = "678767b0-92e7-4007-89e4-4527a8725b19"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/src/lib/PartitionedGraphs/src/partitionedgraph.jl
+++ b/src/lib/PartitionedGraphs/src/partitionedgraph.jl
@@ -152,10 +152,11 @@ function Graphs.rem_edge!(pg::PartitionedGraph, edge::AbstractEdge)
     if se in quotientedges(pg) || reverse(se) in quotientedges(pg)
         g_edges = edges(pg, se)
         if length(g_edges) == 1
-            # Remove the entire super-edge
-            return rem_edge!(pg.quotient_graph, parent(se))
+            # This is the last edge between these partitions, so also remove the super-edge.
+            rem_edge!(pg.quotient_graph, parent(se))
         end
     end
+    # Always remove the underlying edge itself.
     return rem_edge!(pg.graph, edge)
 end
 

--- a/test/test_partitionedgraph.jl
+++ b/test/test_partitionedgraph.jl
@@ -141,6 +141,41 @@ end
     @test nv(QuotientView(pg)) == nx
 end
 
+@testset "Test Partitioned Graph Cross-Partition Edge Removal" begin
+    # Regression test: removing the last edge between two partitions must remove the edge
+    # from the underlying graph, not just the super-edge from the quotient graph.
+    g = NamedGraph([1, 2, 3, 4])
+    pg = PartitionedGraph(g, [[1, 2], [3, 4]])
+
+    # Intra-partition edges (super-edge is a self-loop) round-trip correctly.
+    for e in (NamedEdge(1 => 2), NamedEdge(3 => 4))
+        Graphs.add_edge!(pg, e)
+        @test has_edge(pg, e)
+        Graphs.rem_edge!(pg, e)
+        @test !has_edge(pg, e)
+    end
+
+    # Cross-partition edges: removal must clear both the underlying edge and the super-edge.
+    for e in (NamedEdge(2 => 3), NamedEdge(1 => 4))
+        Graphs.add_edge!(pg, e)
+        se = quotientedge(pg, e)
+        @test has_edge(pg, e)
+        Graphs.rem_edge!(pg, e)
+        @test !has_edge(pg, e)
+        @test !has_edge(unpartitioned_graph(pg), e)
+        @test !has_quotientedge(pg, se)
+    end
+
+    # When several edges share a super-edge, removing one keeps the others and the super-edge.
+    Graphs.add_edge!(pg, NamedEdge(1 => 3))
+    Graphs.add_edge!(pg, NamedEdge(2 => 3))
+    @test has_quotientedge(pg, quotientedge(pg, NamedEdge(1 => 3)))
+    Graphs.rem_edge!(pg, NamedEdge(1 => 3))
+    @test !has_edge(pg, NamedEdge(1 => 3))
+    @test has_edge(pg, NamedEdge(2 => 3))
+    @test has_quotientedge(pg, quotientedge(pg, NamedEdge(2 => 3)))
+end
+
 @testset "Test Partitioned Graph Subgraph Functionality" begin
     n, z = 12, 4
     g = NamedGraph(random_regular_graph(n, z))


### PR DESCRIPTION
This bug was caused by an early `return`, skipping the edge removal from the underlying graph.
